### PR TITLE
refactor(express): replace Bootstrap with plain CSS

### DIFF
--- a/src/express/views/common/header.ejs
+++ b/src/express/views/common/header.ejs
@@ -5,14 +5,6 @@
     <meta title="<%= title %>" />
     <title><%= title %></title>
 
-    <%# Bootstrap %>
-    <link
-        href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
-        rel="stylesheet"
-        integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB"
-        crossorigin="anonymous"
-    />
-
     <%# light-dark polyfill %>
     <%# https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/light-dark %>
     <style>
@@ -32,10 +24,78 @@
             --bg_dark: black;
             --font_light: black;
             --font_dark: white;
+            --surface_light: #ededed;
+            --surface_dark: #1c1c1c;
+            --border_light: #b4b4b4;
+            --border_dark: #4c4c4c;
+            --accent_light: #14477f;
+            --accent_dark: #9dc1f5;
+            --surface_hover_light: #dcdcdc;
+            --surface_hover_dark: #2b2b2b;
+            --accent_hover_light: #0f3560;
+            --accent_hover_dark: #b8d4f8;
+        }
+        *,
+        *::before,
+        *::after {
+            box-sizing: border-box;
         }
         body {
             background-color: var(--light-mode, var(--bg_light)) var(--dark-mode, var(--bg_dark));
             color: var(--light-mode, var(--font_light)) var(--dark-mode, var(--font_dark));
+            font-family: system-ui, sans-serif;
+            line-height: 1.5;
+            margin: 0 auto;
+            max-width: 45rem;
+            padding: 1rem;
+        }
+        a {
+            color: var(--light-mode, var(--accent_light)) var(--dark-mode, var(--accent_dark));
+        }
+        :focus-visible {
+            outline-color: var(--light-mode, var(--accent_light)) var(--dark-mode, var(--accent_dark));
+            outline-offset: 2px;
+            outline-style: solid;
+            outline-width: 2px;
+        }
+        nav ul {
+            display: flex;
+            gap: 0.5rem;
+            list-style: none;
+            margin: 0 0 1.5rem;
+            padding: 0;
+        }
+        nav a {
+            display: inline-block;
+            padding: 0.5rem;
+        }
+        input,
+        textarea {
+            background-color: var(--light-mode, var(--bg_light)) var(--dark-mode, var(--bg_dark));
+            border-color: var(--light-mode, var(--border_light)) var(--dark-mode, var(--border_dark));
+            border-radius: 0.25rem;
+            border-style: solid;
+            border-width: 1px;
+            color: inherit;
+            font: inherit;
+            padding: 0.35rem 0.5rem;
+        }
+        input[type="submit"] {
+            background-color: var(--light-mode, var(--surface_light)) var(--dark-mode, var(--surface_dark));
+            cursor: pointer;
+            padding-inline: 0.9rem;
+        }
+        input[type="submit"]:hover {
+            background-color: var(--light-mode, var(--surface_hover_light)) var(--dark-mode, var(--surface_hover_dark));
+        }
+        input[type="submit"].primary {
+            background-color: var(--light-mode, var(--accent_light)) var(--dark-mode, var(--accent_dark));
+            border-color: var(--light-mode, var(--accent_light)) var(--dark-mode, var(--accent_dark));
+            color: var(--light-mode, var(--bg_light)) var(--dark-mode, var(--bg_dark));
+        }
+        input[type="submit"].primary:hover {
+            background-color: var(--light-mode, var(--accent_hover_light)) var(--dark-mode, var(--accent_hover_dark));
+            border-color: var(--light-mode, var(--accent_hover_light)) var(--dark-mode, var(--accent_hover_dark));
         }
     </style>
 </head>

--- a/src/express/views/common/header.ejs
+++ b/src/express/views/common/header.ejs
@@ -2,7 +2,6 @@
     <%# a11y and SEO %>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta title="<%= title %>" />
     <title><%= title %></title>
 
     <%# light-dark polyfill %>
@@ -26,8 +25,10 @@
             --font_dark: white;
             --surface_light: #ededed;
             --surface_dark: #1c1c1c;
-            --border_light: #b4b4b4;
-            --border_dark: #4c4c4c;
+            --border_light: #767676;
+            --border_dark: #6e6e6e;
+            --muted_light: #595959;
+            --muted_dark: #a8a8a8;
             --accent_light: #14477f;
             --accent_dark: #9dc1f5;
             --surface_hover_light: #dcdcdc;
@@ -57,6 +58,64 @@
             outline-offset: 2px;
             outline-style: solid;
             outline-width: 2px;
+        }
+        h1 {
+            font-size: 1.6rem;
+            line-height: 1.2;
+            margin: 0 0 1rem;
+        }
+        h2 {
+            font-size: 1.15rem;
+            margin: 0 0 0.25rem;
+        }
+        .visually-hidden {
+            clip-path: inset(50%);
+            height: 1px;
+            overflow: hidden;
+            position: absolute;
+            white-space: nowrap;
+            width: 1px;
+        }
+        .messages {
+            display: flex;
+            flex-direction: column;
+            gap: 0.75rem;
+            list-style: none;
+            margin: 0 0 1.5rem;
+            padding: 0;
+        }
+        .messages li {
+            border-color: var(--light-mode, var(--border_light)) var(--dark-mode, var(--border_dark));
+            border-radius: 0.25rem;
+            border-style: solid;
+            border-width: 1px;
+            padding: 0.75rem;
+        }
+        .messages form,
+        .compose {
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+        .meta {
+            color: var(--light-mode, var(--muted_light)) var(--dark-mode, var(--muted_dark));
+            font-size: 0.85rem;
+            margin: 0;
+        }
+        .actions {
+            display: flex;
+            gap: 0.5rem;
+        }
+        .pagination {
+            display: flex;
+            gap: 0.5rem;
+            margin: 0 0 1.5rem;
+        }
+        .compose input[type="submit"] {
+            align-self: flex-start;
+        }
+        textarea {
+            resize: vertical;
         }
         nav ul {
             display: flex;

--- a/src/express/views/common/nav.ejs
+++ b/src/express/views/common/nav.ejs
@@ -1,10 +1,10 @@
 <nav>
-    <ul class="nav">
-        <li class="nav-item">
-            <a href="/" class="nav-link">Home</a>
+    <ul>
+        <li>
+            <a href="/">Home</a>
         </li>
-        <li class="nav-item">
-            <a href="/chat" class="nav-link">Chat</a>
+        <li>
+            <a href="/chat">Chat</a>
         </li>
     </ul>
 </nav>

--- a/src/express/views/common/scripts.ejs
+++ b/src/express/views/common/scripts.ejs
@@ -1,6 +1,0 @@
-<%# Bootstrap %>
-<script
-    src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
-    integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI"
-    crossorigin="anonymous"
-></script>

--- a/src/express/views/pages/chat/index.ejs
+++ b/src/express/views/pages/chat/index.ejs
@@ -13,8 +13,8 @@
                         <input type="text" name="name" placeholder="Display name" value="<%= msg.name %>" />
                         <input type="text" name="content" placeholder="Say something..." value="<%= msg.content %>" />
                         <br />
-                        <input type="submit" formaction="/chat/edit" value="Edit" title="Edit" class="btn" />
-                        <input type="submit" formaction="/chat/delete" value="Delete" title="Delete" class="btn" />
+                        <input type="submit" formaction="/chat/edit" value="Edit" title="Edit" />
+                        <input type="submit" formaction="/chat/delete" value="Delete" title="Delete" />
                     </form>
                 </li>
             <% } %>
@@ -26,8 +26,7 @@
         <form action="/chat/send" method="post">
             <input type="text" name="name" placeholder="Display name" />
             <textarea id="content" name="content" placeholder="Say something..."></textarea>
-            <input type="submit" value="Send" title="Send" class="btn btn-primary" />
+            <input type="submit" value="Send" title="Send" class="primary" />
         </form>
     </body>
-    <%- include('../../common/scripts') %>
 </html>

--- a/src/express/views/pages/chat/index.ejs
+++ b/src/express/views/pages/chat/index.ejs
@@ -4,29 +4,39 @@
     <body>
         <h1>Chat</h1>
         <%- include('../../common/nav') %>
-        <ul>
-            <% for ( let msg of msgs ) { %>
-                <li>
-                    <form method="post">
-                        <input type="hidden" name="id" value="<%= msg.id %>" />
-                        <p>Last modified: <%= msg.lastModified %></p>
-                        <input type="text" name="name" placeholder="Display name" value="<%= msg.name %>" />
-                        <input type="text" name="content" placeholder="Say something..." value="<%= msg.content %>" />
-                        <br />
-                        <input type="submit" formaction="/chat/edit" value="Edit" title="Edit" />
-                        <input type="submit" formaction="/chat/delete" value="Delete" title="Delete" />
-                    </form>
-                </li>
-            <% } %>
-        </ul>
-        <a href="?page=<%= page + 1 %>">Previous</a>
-        <% if (page > 1) { %>
-            <a href="?page=<%= page - 1 %>">Next</a>
-        <% } %>
-        <form action="/chat/send" method="post">
-            <input type="text" name="name" placeholder="Display name" />
-            <textarea id="content" name="content" placeholder="Say something..."></textarea>
-            <input type="submit" value="Send" title="Send" class="primary" />
-        </form>
+        <main>
+            <ul class="messages">
+                <% for ( let msg of msgs ) { %>
+                    <li>
+                        <form method="post">
+                            <input type="hidden" name="id" value="<%= msg.id %>" />
+                            <p class="meta">Last modified: <%= msg.lastModified %></p>
+                            <label class="visually-hidden" for="name-<%= msg.id %>">Display name</label>
+                            <input id="name-<%= msg.id %>" type="text" name="name" autocomplete="off" placeholder="Display name" value="<%= msg.name %>" />
+                            <label class="visually-hidden" for="content-<%= msg.id %>">Message</label>
+                            <input id="content-<%= msg.id %>" type="text" name="content" autocomplete="off" placeholder="Say something..." value="<%= msg.content %>" />
+                            <div class="actions">
+                                <input type="submit" formaction="/chat/edit" value="Edit" />
+                                <input type="submit" formaction="/chat/delete" value="Delete" />
+                            </div>
+                        </form>
+                    </li>
+                <% } %>
+            </ul>
+            <nav class="pagination" aria-label="Message pages">
+                <a href="?page=<%= page + 1 %>">Older messages</a>
+                <% if (page > 1) { %>
+                    <a href="?page=<%= page - 1 %>">Newer messages</a>
+                <% } %>
+            </nav>
+            <form class="compose" action="/chat/send" method="post">
+                <h2>New message</h2>
+                <label for="send-name">Display name</label>
+                <input id="send-name" type="text" name="name" autocomplete="off" placeholder="Display name" />
+                <label for="send-content">Message</label>
+                <textarea id="send-content" name="content" rows="4" autocomplete="off" placeholder="Say something..."></textarea>
+                <input type="submit" value="Send" class="primary" />
+            </form>
+        </main>
     </body>
 </html>

--- a/src/express/views/pages/home/error.ejs
+++ b/src/express/views/pages/home/error.ejs
@@ -4,6 +4,8 @@
     <body>
         <h1><%= code %> <%= name %></h1>
         <%- include('../../common/nav') %>
-        <p>If you think this is an error, please contact this site's maintainers.</p>
+        <main>
+            <p>If you think this is an error, please contact this site's maintainers.</p>
+        </main>
     </body>
 </html>

--- a/src/express/views/pages/home/error.ejs
+++ b/src/express/views/pages/home/error.ejs
@@ -6,5 +6,4 @@
         <%- include('../../common/nav') %>
         <p>If you think this is an error, please contact this site's maintainers.</p>
     </body>
-    <%- include('../../common/scripts') %>
 </html>

--- a/src/express/views/pages/home/index.ejs
+++ b/src/express/views/pages/home/index.ejs
@@ -6,5 +6,4 @@
         <%- include('../../common/nav') %>
         <p>Welcome. Check out some of our pages.</p>
     </body>
-    <%- include('../../common/scripts') %>
 </html>

--- a/src/express/views/pages/home/index.ejs
+++ b/src/express/views/pages/home/index.ejs
@@ -4,6 +4,8 @@
     <body>
         <h1>Home</h1>
         <%- include('../../common/nav') %>
-        <p>Welcome. Check out some of our pages.</p>
+        <main>
+            <p>Welcome. Check out some of our pages.</p>
+        </main>
     </body>
 </html>

--- a/src/express/views/pages/home/status.ejs
+++ b/src/express/views/pages/home/status.ejs
@@ -4,6 +4,8 @@
     <body>
         <h1>Server Status</h1>
         <%- include('../../common/nav') %>
-        <p><%= msg %></p>
+        <main>
+            <p><%= msg %></p>
+        </main>
     </body>
 </html>

--- a/src/express/views/pages/home/status.ejs
+++ b/src/express/views/pages/home/status.ejs
@@ -6,5 +6,4 @@
         <%- include('../../common/nav') %>
         <p><%= msg %></p>
     </body>
-    <%- include('../../common/scripts') %>
 </html>


### PR DESCRIPTION
Closes #162
Closes #116

## Problem

`common/header.ejs` and `common/scripts.ejs` pulled Bootstrap's stylesheet and JS bundle from `cdn.jsdelivr.net`, so every page load on the hidden service also reached the clearnet. The bundle did nothing besides: no markup uses a `data-bs-*` attribute.

The sample pages were also unstructured. The message list kept its default bullets and indentation, fields sat inline with no spacing, and nothing separated one message from the next.

## What changed

Bootstrap supplied five classes: `nav`, `nav-item`, `nav-link`, `btn` and `btn btn-primary`. They are replaced with plain rules in the style block already in `header.ejs`. The `nav` classes give way to semantic selectors, and `btn btn-primary` becomes `primary`, so no framework naming remains. New colors are `_light`/`_dark` pairs consumed through the same toggle already used here and in `src/nginx/html/error.html`, so the theming mechanism is unchanged. `border` and `outline` use longhands, since the toggle does not sit inside a shorthand.

`common/scripts.ejs` held nothing but the bundle's `<script>` tag, so it and its four includes are removed.

Messages are now bordered blocks in a column, each form stacks its fields, and the edit and delete buttons are grouped. The compose form gains a heading and visible labels.

For a11y, which also covers part of #170:

- Every input has a `label`, hidden on existing messages so the rows stay compact, visible on the compose form
- Content sits in a `main` landmark
- Pagination links say which direction they go, and their `nav` is labeled
- Border and muted text colors meet WCAG contrast in both themes
- `<meta title>` is dropped, since no such attribute exists

Fields are `autocomplete="off"`, so a browser does not retain what was typed into an anonymous board.

No JavaScript is added and nothing is fetched. The stylesheet stays inline.

## Verification

All four templates render with no reference to an external host, every `for` resolves to a matching `id`, and there are no duplicate ids. eslint, markdownlint and tsc pass.

This was verified by rendering the templates and by inspection, not visually, since no browser was available here. Worth a glance on your end.

A page is 5 to 8 KB, against roughly 310 KB uncompressed previously fetched from the CDN.

## Note

This branches from `main` and is independent of #273, though both touch these templates. Whichever lands second will want a rebase.


Supersedes #274, which closed when I force-pushed a signed rewrite of these commits and the branch ref briefly went missing. Same content, plus signatures.
