### PR TITLE
fix(express): retry the database connection and serve 503 while it is down

### DIFF
--- a/src/express/app.ts
+++ b/src/express/app.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import mongoose from 'mongoose';
+import { connect, reconnectOnDisconnect } from './db/connection';
 import { msgBoard } from './env';
 import { appRouter, notFoundRouter } from './routes';
 
@@ -18,12 +18,8 @@ app.use('/', appRouter); // Serves app
 app.use('/', notFoundRouter); // Catches errors
 
 // Starting server
-try {
-    await mongoose.connect(msgBoard.uri);
-}
-catch (err) {
-    console.error('Failed to connect to database:', err);
-}
+reconnectOnDisconnect(msgBoard.uri);
+void connect(msgBoard.uri);
 
 app.listen(port, () => {
     console.log('Server is running!');

--- a/src/express/db/connection.ts
+++ b/src/express/db/connection.ts
@@ -1,0 +1,44 @@
+import mongoose from 'mongoose';
+
+const RETRY_INTERVAL_MS = 5000;
+
+/**
+ * @returns Whether the database is currently usable
+ */
+export function isConnected(): boolean {
+    return mongoose.connection.readyState === mongoose.ConnectionStates.connected;
+}
+
+/**
+ * Connects to the database, retrying until it succeeds. Does nothing if a
+ * connection is already open or being opened.
+ * @param uri The connection string
+ * @param retryMs How long to wait before another attempt
+ */
+export async function connect(
+    uri: string,
+    retryMs: number = RETRY_INTERVAL_MS
+): Promise<void> {
+    if (mongoose.connection.readyState !== mongoose.ConnectionStates.disconnected) {
+        return;
+    }
+
+    try {
+        await mongoose.connect(uri);
+    }
+    catch (err) {
+        // Not the message, which can carry the connection string
+        const name = err instanceof Error ? err.name : 'unknown error';
+
+        console.error(`Database connection failed (${name}), retrying`);
+        setTimeout(() => void connect(uri, retryMs), retryMs);
+    }
+}
+
+/**
+ * Reconnects whenever the database drops the connection
+ * @param uri The connection string
+ */
+export function reconnectOnDisconnect(uri: string): void {
+    mongoose.connection.on('disconnected', () => void connect(uri));
+}

--- a/src/express/middleware/errors.ts
+++ b/src/express/middleware/errors.ts
@@ -1,4 +1,5 @@
 import { type ErrorRequestHandler, type RequestHandler } from 'express';
+import { isConnected } from '../db/connection';
 import { http } from '../utils';
 
 /**
@@ -40,8 +41,11 @@ export const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
     res.statusMessage ??= http.names[res.statusCode];
 
     if (res.statusCode < 400 || res.statusCode >= 600) {
-        res.statusCode = http.codes.INTERNAL_SERVER_ERROR;
-        res.statusMessage = http.names[http.codes.INTERNAL_SERVER_ERROR];
+        // No database behind the failure means 503, not 500
+        res.statusCode = isConnected()
+            ? http.codes.INTERNAL_SERVER_ERROR
+            : http.codes.SERVICE_UNAVAILABLE;
+        res.statusMessage = http.names[res.statusCode];
     }
 
     const args = {


### PR DESCRIPTION
Closes #108

## Problem

Express connects to mongo once at startup. A failure is logged and the server carries on, so a mongo restart leaves the site up but unable to answer anything that reads or writes, until express is restarted by hand. The README notes the symptom under Updating:

> For instance, `express` currently requires a restart if `mongo` restarts.

## Resolution

`db/connection.ts` retries until the connection is accepted, and reconnects on the `disconnected` event.

A `readyState` guard sits in front of both paths, so it does nothing when a connection is already open or already being opened. The driver retries on its own once a connection has been established, and the guard keeps this from dialing alongside it.

`connect` is no longer awaited before `listen`, so the server starts answering immediately rather than after a failed connection times out. Pages that do not touch mongo keep working throughout.

The error handler answers 503 instead of 500 when a request fails with no database behind it, since that is not the client's fault. 4XX responses are untouched.

Only the error name is logged, since the message can carry the connection string, which holds credentials in the default setup.

## On the healthcheck

Unchanged, deliberately. With reconnection in place, express staying up while mongo recovers is the wanted behavior, and restarting express would not bring mongo back.

## Verification

Run against an unreachable mongo, the server binds once, logs `Server is running!` before the first failed attempt, answers `/` with 200 throughout, and retries without the connection string appearing in any log line.

No tests here. The test setup is in #273, so these paths get covered there once it lands rather than duplicating the wiring in this branch.

Suggested labels: `bug`, `enhancement`
