### PR TITLE
chore: fix CodeQL configuration in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         node-version: [24.x]
-        languages: [javascript-typescript]
+        languages: [actions, javascript-typescript]
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.languages }}
-          build-mode: manual
+          build-mode: none
       - name: Build Express app
         run: npm -w ./src/express run build
       - name: Perform CodeQL Analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           languages: ${{ matrix.languages }}
           build-mode: none
+      - name: Install node modules
+        run: npm ci --no-fund
       - name: Build Express app
         run: npm -w ./src/express run build
       - name: Perform CodeQL Analysis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
-      - uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/init@main
         with:
           languages: ${{ matrix.languages }}
           build-mode: none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,33 @@ env:
   DOCKER_COMPOSE_VERSION: v5.4.0
 
 jobs:
+  # Scans code using CodeQL
+  analyze:
+    permissions:
+      contents: read
+      security-events: write
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04]
+        node-version: [24.x]
+        languages: [javascript-typescript]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+      - uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.languages }}
+          build-mode: manual
+      - name: Build Express app
+        run: npm -w ./src/express run build
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@main
   # Builds Docker compose services
   build:
     permissions:


### PR DESCRIPTION
The required CodeQL configuration now runs in PRs, avoiding the need for an admin override to merge.