### PR TITLE
ci: analyse pull requests with CodeQL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,35 +8,6 @@ env:
   DOCKER_COMPOSE_VERSION: v5.4.0
 
 jobs:
-  # Scans code using CodeQL
-  analyze:
-    permissions:
-      contents: read
-      security-events: write
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04]
-        node-version: [24.x]
-        languages: [actions, javascript-typescript]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v7
-        with:
-          node-version: ${{ matrix.node-version }}
-      - uses: github/codeql-action/init@main
-        with:
-          languages: ${{ matrix.languages }}
-          build-mode: none
-      - name: Install node modules
-        run: npm ci --no-fund
-      - name: Build Express app
-        run: npm -w ./src/express run build
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@main
   # Builds Docker compose services
   build:
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,31 @@
+name: CodeQL
+
+# A fork's push runs in the fork, so its results are reported there rather
+# than on the pull request. Analysing the merge commit reports them here.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  # Scans code using CodeQL
+  analyze:
+    permissions:
+      contents: read
+      security-events: write
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04]
+        languages: [actions, javascript-typescript]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - uses: github/codeql-action/init@main
+        with:
+          languages: ${{ matrix.languages }}
+          build-mode: none
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@main


### PR DESCRIPTION
## Problem

Every pull request from a fork sits on:

```text
Code scanning is waiting for results from CodeQL for the commits
9d2a8d8 or aa40a7e.
```

`ci.yml` only triggers `on: push`, so a fork's branch is analysed in the
fork and the result is uploaded there. This repository never receives one
for the head or the merge commit, so the wait doesn't end. #273 and #278
both show it.

Separately, `analyze` sets `build-mode: none`, which extracts the sources
without a build. The install and build steps before it only left the
webpack bundle behind for the extractor to pick up:

```text
Extracting .../src/express/dist/index.cjs
```

That is `express`, `mongoose`, `ejs` and `mongodb` bundled into one file,
scanned as if it were ours.

## Solution

Move the job into `codeql.yml` and add a `pull_request` trigger, so the
merge commit is analysed against this repository. `push` stays for `main`,
which keeps the default branch scanned without running the whole matrix
twice on every pull request.

The install and build steps go, since `build-mode: none` doesn't use them.

This pull request analyses itself: its merge commit carries the new
workflow, so CodeQL reports here rather than waiting. Open ones pick it up
on their next push once this lands.

Suggested labels: ci
