### PR TITLE
ci: run the workflow on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,12 @@
 name: CI
 
+# A fork's push runs in the fork, so its results are reported there rather
+# than on the pull request. Running on the merge commit reports them here.
 on:
   push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 env:
   DOCKER_VERSION: v29.7.2


### PR DESCRIPTION
Closes #293

## Problem

`ci.yml` triggers on `push` only. A pull request from a fork pushes to
the fork, so the run happens there and the result is reported there.
This repository never receives one, and none of `ci.yml`'s jobs appear
on the pull request. #285 was reviewed with this check list:

```text
CodeQL                                     skipping
Socket Security: Project Report            pass
Socket Security: Pull Request Alerts       pass
analyze (ubuntu-24.04, actions)            pass
analyze (ubuntu-24.04, javascript-typescript)  pass
```

`analyze` is there because #285 gave `codeql.yml` a `pull_request`
trigger. `build`, `npm`, `markdownlint`, `eslint`, `tsc`, `workspaces`,
`test` and `smoke` are not. #278 was reviewed this way with a failing
`workspaces` job, and nothing on the pull request said so.

## Resolution

The trigger block `codeql.yml` already uses, so the two workflows agree:

```yaml
on:
  push:
    branches: [main]
  pull_request:
    branches: [main]
```

#293 sketched an unrestricted `push` next to `pull_request`, and noted a
branch with an open pull request would then run twice. Narrowing `push`
to `main` removes the second run rather than cancelling it: a
`concurrency` group cancels whichever queued first, and the webhook order
is not fixed, so the cancelled one would sometimes be the pull request's
— the symptom this closes. It also keeps `test` and `smoke` from running
twice, which `smoke` waits up to 900s for.

The cost is that a branch pushed with no open pull request is no longer
built. `main`, pull requests and Dependabot branches all still are.

## Verification

- This pull request runs itself. `pull_request` reads the workflow from
  the merge commit, so the jobs in the check list below come from this
  branch. Open pull requests pick it up on their next push once this
  lands.
- The read-only token a fork's pull request receives is enough, since no
  job needs a secret: `ci.yml` references none, `smoke.sh` writes its
  `.env` files from the committed `.example`s and generates
  `keyFile.pem` with `openssl`, and the `onionprobe` submodule is a
  public HTTPS URL.
- The trigger block parses to the same value as `codeql.yml`'s, and no
  job reads `github.ref` or another context that only a push populates.

Suggested labels: `github_actions`
