### PR TITLE
feat(express): overhaul the pages: readable messages, validation without scripts, and a tokenized theme

### DIFF
--- a/src/express/controllers/chat.ts
+++ b/src/express/controllers/chat.ts
@@ -1,9 +1,89 @@
-import { type RequestHandler } from 'express';
+import { type Request, type RequestHandler, type Response } from 'express';
 import { validationResult } from 'express-validator';
 import { ObjectId, type WithId } from 'mongodb';
 import { MsgBoard } from '../db';
+import { MSG_PAGE_SIZE } from '../db/msgBoard';
 import { http } from '../utils';
 import { redirect } from '../utils/shims';
+
+/** The last page whose $skip fits a 32-bit integer */
+const MAX_PAGE = Math.floor((2 ** 31 - 1) / MSG_PAGE_SIZE);
+
+/** Validation messages keyed by form field */
+type FieldErrors = Partial<Record<'name' | 'content' | 'id', string>>;
+
+/** A rejected submission, echoed back into the form it came from */
+interface Rejected {
+    errors: FieldErrors;
+    /** The message being edited or deleted, if any */
+    id?: string;
+    name?: string;
+    content?: string;
+}
+
+/**
+ * Reads the 1-indexed page number from the query string
+ * @param req The request
+ * @returns The page number, defaulting to the first page
+ */
+function getPage(req: Request): number {
+    const params = req.query as { page?: string };
+    const rawPage = Number(params.page);
+
+    if (!Number.isFinite(rawPage)) {
+        return 1;
+    }
+
+    // Keeps the pipeline's $skip within a 32-bit integer
+    return Math.min(Math.max(1, Math.trunc(rawPage)), MAX_PAGE);
+}
+
+/**
+ * Renders the message board
+ * @param req The request
+ * @param res The response
+ * @param rejected A rejected submission to show alongside the board
+ */
+async function renderBoard(req: Request, res: Response, rejected?: Rejected): Promise<void> {
+    const page = getPage(req);
+    const msgs = await MsgBoard.getMsgs(page);
+    const formattedMsgs = msgs.map((e) => ({
+        id: e._id.toString(),
+        name: e.name,
+        content: e.content,
+        lastModified: new Date(e.lastModified).toLocaleString('en-US', {
+            dateStyle: 'long',
+            timeStyle: 'long',
+            timeZone: 'UTC'
+        }),
+        dateTime: new Date(e.lastModified).toISOString()
+    }));
+    const args = {
+        msgs: formattedMsgs,
+        page: page,
+        hasOlder: msgs.length === MSG_PAGE_SIZE,
+        rejected: rejected ?? { errors: {} }
+    };
+
+    res.render('pages/chat', args);
+}
+
+/**
+ * Collects validation messages by field
+ * @param req The request
+ * @returns The first message for each failing field
+ */
+function fieldErrors(req: Request): FieldErrors {
+    const errors: FieldErrors = {};
+
+    for (const [field, error] of Object.entries(validationResult(req).mapped())) {
+        if (field === 'name' || field === 'content' || field === 'id') {
+            errors[field] = String(error.msg);
+        }
+    }
+
+    return errors;
+}
 
 /**
  * Displays the chat home page
@@ -11,46 +91,30 @@ import { redirect } from '../utils/shims';
  * @param res The response
  */
 export const getChat: RequestHandler = async (req, res) => {
-    const params = req.query as { page?: string };
-    const rawPage = Number(params.page);
-    const page = Number.isFinite(rawPage) ? Math.max(1, Math.trunc(rawPage)) : 1;
-    const msgs = await MsgBoard.getMsgs(page);
-    const formattedMsgs = msgs.map((e) => ({
-        id: e._id,
-        name: e.name,
-        content: e.content,
-        lastModified: new Date(e.lastModified).toLocaleString('en-US', {
-            dateStyle: 'long',
-            timeStyle: 'long',
-            timeZone: 'UTC'
-        })
-    }));
-    const args = {
-        msgs: formattedMsgs,
-        page: page
-    };
-
-    res.render('pages/chat', args);
+    await renderBoard(req, res);
 };
 
 /**
  * Creates a new message
  * @param req The request
  * @param res The response
- * @param next The callback function for the next middleware
  */
-export const sendMsg: RequestHandler = async (req, res, next) => {
-    // Placeholder error page
-    if (!validationResult(req).isEmpty()) {
-        res.statusCode = http.codes.BAD_REQUEST;
-        next(validationResult(req).array()[0]);
-        return;
-    }
-
+export const sendMsg: RequestHandler = async (req, res) => {
     const params = req.body as {
         name: string;
         content: string;
     };
+
+    if (!validationResult(req).isEmpty()) {
+        res.status(http.codes.BAD_REQUEST);
+        await renderBoard(req, res, {
+            errors: fieldErrors(req),
+            name: params.name,
+            content: params.content
+        });
+        return;
+    }
+
     const msg: MsgBoard.Msg = {
         name: params.name,
         content: params.content
@@ -65,21 +129,25 @@ export const sendMsg: RequestHandler = async (req, res, next) => {
  * Updates a message
  * @param req The request
  * @param res The response
- * @param next The callback function for the next middleware
  */
-export const editMsg: RequestHandler = async (req, res, next) => {
-    // Placeholder error page
-    if (!validationResult(req).isEmpty()) {
-        res.statusCode = http.codes.BAD_REQUEST;
-        next(validationResult(req).array()[0]);
-        return;
-    }
-
+export const editMsg: RequestHandler = async (req, res) => {
     const params = req.body as {
         name: string;
         content: string;
         id: string;
     };
+
+    if (!validationResult(req).isEmpty()) {
+        res.status(http.codes.BAD_REQUEST);
+        await renderBoard(req, res, {
+            errors: fieldErrors(req),
+            id: params.id,
+            name: params.name,
+            content: params.content
+        });
+        return;
+    }
+
     const newMsg: WithId<MsgBoard.Msg> = {
         _id: new ObjectId(params.id),
         name: params.name,
@@ -95,17 +163,19 @@ export const editMsg: RequestHandler = async (req, res, next) => {
  * Deletes a message
  * @param req The request
  * @param res The response
- * @param next The callback function for the next middleware
  */
-export const deleteMsg: RequestHandler = async (req, res, next) => {
-    // Placeholder error page
+export const deleteMsg: RequestHandler = async (req, res) => {
+    const params = req.body as { id: string };
+
     if (!validationResult(req).isEmpty()) {
-        res.statusCode = http.codes.BAD_REQUEST;
-        next(validationResult(req).array()[0]);
+        res.status(http.codes.BAD_REQUEST);
+        await renderBoard(req, res, {
+            errors: fieldErrors(req),
+            id: params.id
+        });
         return;
     }
 
-    const params = req.body as { id: string };
     const id = new ObjectId(params.id);
 
     await MsgBoard.deleteMsg(id);

--- a/src/express/db/msgBoard.ts
+++ b/src/express/db/msgBoard.ts
@@ -2,7 +2,7 @@ import { ObjectId, type WithId } from 'mongodb';
 import mongoose, { type PipelineStage, Schema } from 'mongoose';
 import { dateNow } from '../utils/shims';
 
-const MSG_PAGE_SIZE = 10;
+export const MSG_PAGE_SIZE = 10;
 
 export interface Msg {
     name: string;

--- a/src/express/middleware/errors.ts
+++ b/src/express/middleware/errors.ts
@@ -35,6 +35,14 @@ export const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
 
     console.error('Handled uncaught error:', newErr);
 
+    // A body parser error carries its own status, such as 413 for an oversized body
+    const status: unknown = (err as { status?: unknown } | null)?.status;
+
+    if (typeof status === 'number' && status >= 400 && status < 600) {
+        res.statusCode = status;
+        res.statusMessage = http.names[status];
+    }
+
     // Giving limited error information to the client
     // res.statusMessage can be undefined
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/src/express/middleware/validators/chat.ts
+++ b/src/express/middleware/validators/chat.ts
@@ -2,31 +2,57 @@ import { body } from 'express-validator';
 import { ObjectId } from 'mongodb';
 import { MsgBoard } from '../../db';
 
+/** Bidirectional overrides can make a name render as different text than it is */
+const BIDI_CONTROLS = /[\u{202A}-\u{202E}\u{2066}-\u{2069}]/u;
+/** Control characters other than tab and newline */
+const CONTROLS_EXCEPT_WHITESPACE = /[^\P{Cc}\t\n]/u;
+/** Any control character */
+const CONTROLS = /\p{Cc}/u;
+/** At least one character that is neither whitespace nor an invisible format character */
+const VISIBLE = /[^\s\p{Cf}]/u;
+
+/**
+ * Normalizes line endings, so a message is measured the same way the browser measured it
+ * @param value The submitted value
+ * @returns The value with `\r\n` and lone `\r` as `\n`
+ */
+function normalizeNewlines(value: unknown): unknown {
+    return typeof value === 'string' ? value.replace(/\r\n?/g, '\n') : value;
+}
+
 const idValidator = body('id')
-    .trim()
     // Is stringified ObjectId (24 hexadecimal characters)
     .isString()
+    .withMessage('Invalid id')
+    .bail()
+    .trim()
     .isLength({ min: 24, max: 24 })
+    .withMessage('Invalid id')
+    .bail()
     .isHexadecimal()
+    .withMessage('Invalid id')
+    .bail()
     .custom((rawId: string) => ObjectId.isValid(rawId))
     .withMessage('Invalid id')
     .bail()
-    // Id exists in database
+    // Id exists in database. A resolved promise always passes, so the check has to throw
     .custom(async (rawId: string) => {
         const id = new ObjectId(rawId);
 
-        return await MsgBoard.idExists(id);
+        if (!await MsgBoard.idExists(id)) {
+            throw new Error('That message no longer exists');
+        }
     })
-    .withMessage('Invalid id')
     .bail();
 
 const nameValidator = body('name')
-    // Is string
+    // Is a single string
     .isString()
-    .withMessage('Invalid display name')
+    .withMessage('Please enter your display name')
     .bail()
-    // Is not empty
-    .notEmpty()
+    .trim()
+    // Has something visible in it
+    .matches(VISIBLE)
     .withMessage('Please enter your display name')
     .bail()
     // Is between 1 and 32 characters
@@ -34,11 +60,26 @@ const nameValidator = body('name')
     .withMessage(
         'Display name must be between 1 and 32 characters, inclusive'
     )
+    .bail()
+    // Stays on one line and renders as typed
+    .not()
+    .matches(CONTROLS)
+    .withMessage('Display name cannot contain control characters')
+    .bail()
+    .not()
+    .matches(BIDI_CONTROLS)
+    .withMessage('Display name cannot contain text direction controls')
     .bail();
 
 const contentValidator = body('content')
+    // Is a single string
     .isString()
-    .notEmpty()
+    .withMessage('Please enter a message')
+    .bail()
+    .customSanitizer(normalizeNewlines)
+    .trim()
+    // Has something visible in it
+    .matches(VISIBLE)
     .withMessage('Please enter a message')
     .bail()
     // Is between 1 and 2048 characters
@@ -46,6 +87,11 @@ const contentValidator = body('content')
     .withMessage((value: string) =>
         `Message must be between 1 and 2048 characters, inclusive (got ${value.length.toString()})`
     )
+    .bail()
+    // Plain text: tabs and newlines only
+    .not()
+    .matches(CONTROLS_EXCEPT_WHITESPACE)
+    .withMessage('Message cannot contain control characters')
     .bail();
 
 export const sendMsgValidators = [

--- a/src/express/test/routes.test.ts
+++ b/src/express/test/routes.test.ts
@@ -82,6 +82,7 @@ void describe('routes', () => {
     });
 
     void it('rejects a message with no content', async (t: TestContext) => {
+        stubAggregate(t, []);
         const insertOne = t.mock.method(MsgModel, 'insertOne',
             () => Promise.resolve() as unknown as ReturnType<typeof MsgModel.insertOne>);
 
@@ -102,10 +103,142 @@ void describe('routes', () => {
         assert.equal(insertOne.mock.callCount(), 1);
     });
 
-    void it('rejects a delete with a malformed id', async () => {
+    void it('rejects a delete with a malformed id', async (t: TestContext) => {
+        stubAggregate(t, []);
+
         const res = await post('/chat/delete', { id: 'not-a-valid-object-id' });
 
         assert.equal(res.status, http.codes.BAD_REQUEST);
+    });
+
+    void it('shows a rejected message on the board with its input kept', async (t: TestContext) => {
+        stubAggregate(t, []);
+
+        const res = await post('/chat/send', { name: 'ann', content: '' });
+        const body = await res.text();
+
+        assert.equal(res.status, http.codes.BAD_REQUEST);
+        assert.match(body, /Please enter a message/);
+        assert.match(body, /id="send-content-error"/);
+        assert.match(body, /aria-invalid="true" aria-describedby="send-content-error"/);
+        assert.match(body, /id="send-name" [^>]*value="ann"/);
+    });
+
+    void it('shows a rejected delete on the board', async (t: TestContext) => {
+        stubAggregate(t, []);
+        t.mock.method(MsgModel, 'findById',
+            () => Promise.resolve(null) as unknown as ReturnType<typeof MsgModel.findById>);
+
+        const res = await post('/chat/delete', { id: '0123456789abcdef01234567' });
+        const body = await res.text();
+
+        assert.equal(res.status, http.codes.BAD_REQUEST);
+        assert.match(body, /<p class="error" role="alert">That message no longer exists<\/p>/);
+    });
+
+    void it('rejects a name or message that is only whitespace', async (t: TestContext) => {
+        stubAggregate(t, []);
+        const insertOne = t.mock.method(MsgModel, 'insertOne',
+            () => Promise.resolve() as unknown as ReturnType<typeof MsgModel.insertOne>);
+
+        const blankName = await post('/chat/send', { name: '   ', content: 'hello' });
+        const zeroWidthName = await post('/chat/send', { name: '\u200B', content: 'hello' });
+        const blankContent = await post('/chat/send', { name: 'ann', content: ' \n\t ' });
+
+        assert.equal(blankName.status, http.codes.BAD_REQUEST);
+        assert.equal(zeroWidthName.status, http.codes.BAD_REQUEST);
+        assert.equal(blankContent.status, http.codes.BAD_REQUEST);
+        assert.match(await blankName.text(), /Please enter your display name/);
+        assert.match(await blankContent.text(), /Please enter a message/);
+        assert.equal(insertOne.mock.callCount(), 0);
+    });
+
+    void it('rejects control and text direction characters', async (t: TestContext) => {
+        stubAggregate(t, []);
+        const insertOne = t.mock.method(MsgModel, 'insertOne',
+            () => Promise.resolve() as unknown as ReturnType<typeof MsgModel.insertOne>);
+
+        const newlineName = await post('/chat/send', { name: 'an\nn', content: 'hello' });
+        const bidiName = await post('/chat/send', { name: 'ann\u202E', content: 'hello' });
+        const nullContent = await post('/chat/send', { name: 'ann', content: 'hel\u0000lo' });
+
+        assert.equal(newlineName.status, http.codes.BAD_REQUEST);
+        assert.equal(bidiName.status, http.codes.BAD_REQUEST);
+        assert.equal(nullContent.status, http.codes.BAD_REQUEST);
+        assert.match(await bidiName.text(), /text direction/);
+        assert.equal(insertOne.mock.callCount(), 0);
+    });
+
+    void it('counts a submitted CRLF as the one character the browser counted', async (t: TestContext) => {
+        const insertOne = t.mock.method(MsgModel, 'insertOne',
+            () => Promise.resolve() as unknown as ReturnType<typeof MsgModel.insertOne>);
+
+        // 1024 lines of "a" joined by CRLF: 2047 characters once normalized, 3070 as sent
+        const content = Array<string>(1024).fill('a').join('\r\n');
+        const res = await post('/chat/send', { name: 'ann', content });
+
+        assert.equal(res.status, http.codes.SEE_OTHER);
+        assert.equal(insertOne.mock.callCount(), 1);
+        const stored = insertOne.mock.calls[0]?.arguments[0] as { content: string };
+        assert.doesNotMatch(stored.content, /\r/);
+        assert.equal(stored.content.length, 2047);
+    });
+
+    void it('rejects a field sent more than once', async (t: TestContext) => {
+        stubAggregate(t, []);
+        const insertOne = t.mock.method(MsgModel, 'insertOne',
+            () => Promise.resolve() as unknown as ReturnType<typeof MsgModel.insertOne>);
+
+        const res = await fetch(base + '/chat/send', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: 'name=ann&name=bob&content=hello',
+            redirect: 'manual'
+        });
+
+        assert.equal(res.status, http.codes.BAD_REQUEST);
+        assert.match(await res.text(), /Please enter your display name/);
+        assert.equal(insertOne.mock.callCount(), 0);
+    });
+
+    void it('rejects a message over the limit and says by how much', async (t: TestContext) => {
+        stubAggregate(t, []);
+
+        const res = await post('/chat/send', { name: 'ann', content: 'a'.repeat(2049) });
+
+        assert.equal(res.status, http.codes.BAD_REQUEST);
+        assert.match(await res.text(), /got 2049/);
+    });
+
+    void it('clamps the page number', async (t: TestContext) => {
+        const aggregate = stubAggregate(t, []);
+
+        await fetch(base + '/chat?page=1e300');
+        await fetch(base + '/chat?page=-5');
+
+        const stages = aggregate.mock.calls[0]?.arguments[0] as { $skip?: number }[];
+        const skip = stages.find((stage) => stage.$skip != null)?.$skip;
+        assert.ok(skip != null && skip <= 2 ** 31 - 1);
+        assert.equal((aggregate.mock.calls[1]?.arguments[0] as unknown[]).length, 2);
+    });
+
+    void it('constrains the compose form without scripts', async (t: TestContext) => {
+        stubAggregate(t, []);
+
+        const body = await (await fetch(base + '/chat')).text();
+
+        assert.match(body, /name="name" [^>]*required maxlength="32" pattern=/);
+        assert.match(body, /name="content" [^>]*required maxlength="2048"/);
+        assert.doesNotMatch(body, /<script/);
+    });
+
+    void it('marks the current page in the navigation', async () => {
+        const body = await (await fetch(base + '/')).text();
+
+        assert.match(body, /<a href="\/" aria-current="page">Home<\/a>/);
+        assert.doesNotMatch(body, /<a href="\/chat" aria-current="page">/);
+        assert.match(body, /class="skip" href="#main"/);
+        assert.match(body, /<main id="main">/);
     });
 
     void it('reports a failed query without leaking the cause', async (t: TestContext) => {
@@ -121,6 +254,27 @@ void describe('routes', () => {
         assert.doesNotMatch(body, /connection refused/);
         assert.doesNotMatch(body, /stack/);
         assert.doesNotMatch(body, /trace/);
+    });
+
+    void it('answers a malformed JSON body with 400, not the database status', async () => {
+        const res = await fetch(base + '/chat/send', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{not json',
+            redirect: 'manual'
+        });
+        const body = await res.text();
+
+        assert.equal(res.status, http.codes.BAD_REQUEST);
+        assert.match(body, /400 Bad Request/);
+        assert.doesNotMatch(body, /Unexpected token|JSON|body-parser/);
+    });
+
+    void it('answers an oversized body with 413', async () => {
+        const res = await post('/chat/send', { name: 'ann', content: 'a'.repeat(150_000) });
+
+        assert.equal(res.status, http.codes.CONTENT_TOO_LARGE);
+        assert.match(await res.text(), /413 /);
     });
 
     void it('omits the Server header', async () => {

--- a/src/express/views/common/header.ejs
+++ b/src/express/views/common/header.ejs
@@ -85,6 +85,12 @@
         .skip:focus {
             transform: none;
         }
+        main {
+            scroll-margin-top: 1rem;
+        }
+        p {
+            text-wrap: pretty;
+        }
         h1 {
             font-size: 1.6rem;
             line-height: 1.2;
@@ -110,18 +116,39 @@
             margin: 0 0 1.5rem;
             padding: 0;
         }
-        .messages li,
+        .message,
         .error {
             overflow-wrap: anywhere;
         }
-        .messages li {
+        .message {
             border-color: var(--border);
             border-radius: 0.25rem;
             border-style: solid;
             border-width: 1px;
             padding: 0.75rem;
         }
-        .messages form,
+        .message .content {
+            margin: 0.25rem 0 0.5rem;
+            white-space: pre-wrap;
+        }
+        .message details {
+            border-top-color: var(--border);
+            border-top-style: solid;
+            border-top-width: 1px;
+            margin: 0 -0.75rem -0.75rem;
+            padding: 0 0.75rem;
+        }
+        .message summary {
+            color: var(--accent);
+            cursor: pointer;
+            min-height: 2.25rem;
+            padding: 0.5rem 0;
+            width: fit-content;
+        }
+        .message details form {
+            padding-bottom: 0.75rem;
+        }
+        .message form,
         .compose {
             display: flex;
             flex-direction: column;
@@ -134,6 +161,11 @@
         }
         .meta {
             font-size: 0.85rem;
+        }
+        .meta b {
+            color: var(--fg);
+            font-size: 1rem;
+            margin-right: 0.5rem;
         }
         .empty {
             margin-bottom: 1.5rem;
@@ -159,6 +191,8 @@
             align-self: flex-start;
         }
         textarea {
+            field-sizing: content;
+            min-height: 4.5rem;
             resize: vertical;
         }
         nav ul {

--- a/src/express/views/common/header.ejs
+++ b/src/express/views/common/header.ejs
@@ -5,8 +5,8 @@
     <title><%= title %></title>
     <%# Paints the right background before the stylesheet is parsed %>
     <meta name="color-scheme" content="light dark" />
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="white" />
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="black" />
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f5f6f8" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0f1115" />
     <%# No favicon request, no referrer on outbound links %>
     <link rel="icon" href="data:," />
     <meta name="referrer" content="no-referrer" />
@@ -27,26 +27,28 @@
             }
         }
         html {
-            --bg: var(--light-mode, white) var(--dark-mode, black);
-            --fg: var(--light-mode, black) var(--dark-mode, white);
-            --surface: var(--light-mode, #ededed) var(--dark-mode, #1c1c1c);
-            --surface-hover: var(--light-mode, #dcdcdc) var(--dark-mode, #2b2b2b);
-            --border: var(--light-mode, #767676) var(--dark-mode, #6e6e6e);
-            --muted: var(--light-mode, #595959) var(--dark-mode, #a8a8a8);
-            --accent: var(--light-mode, #14477f) var(--dark-mode, #9dc1f5);
-            --accent-hover: var(--light-mode, #0f3560) var(--dark-mode, #b8d4f8);
+            --bg: var(--light-mode, #f5f6f8) var(--dark-mode, #0f1115);
+            --fg: var(--light-mode, #171a1f) var(--dark-mode, #e8eaf0);
+            --surface: var(--light-mode, #ffffff) var(--dark-mode, #181b22);
+            --surface-hover: var(--light-mode, #eceef2) var(--dark-mode, #232733);
+            --border: var(--light-mode, #7f8898) var(--dark-mode, #6b7382);
+            --muted: var(--light-mode, #59616e) var(--dark-mode, #9aa3b2);
+            --accent: var(--light-mode, #2a4fb8) var(--dark-mode, #8fb5ff);
+            --accent-hover: var(--light-mode, #1f3d94) var(--dark-mode, #acc7ff);
+            --on-accent: var(--light-mode, #ffffff) var(--dark-mode, #0f1115);
             --error: var(--light-mode, #a3261d) var(--dark-mode, #ffb4ab);
         }
         @supports (color: light-dark(black, white)) {
             html {
-                --bg: light-dark(white, black);
-                --fg: light-dark(black, white);
-                --surface: light-dark(#ededed, #1c1c1c);
-                --surface-hover: light-dark(#dcdcdc, #2b2b2b);
-                --border: light-dark(#767676, #6e6e6e);
-                --muted: light-dark(#595959, #a8a8a8);
-                --accent: light-dark(#14477f, #9dc1f5);
-                --accent-hover: light-dark(#0f3560, #b8d4f8);
+                --bg: light-dark(#f5f6f8, #0f1115);
+                --fg: light-dark(#171a1f, #e8eaf0);
+                --surface: light-dark(#ffffff, #181b22);
+                --surface-hover: light-dark(#eceef2, #232733);
+                --border: light-dark(#7f8898, #6b7382);
+                --muted: light-dark(#59616e, #9aa3b2);
+                --accent: light-dark(#2a4fb8, #8fb5ff);
+                --accent-hover: light-dark(#1f3d94, #acc7ff);
+                --on-accent: light-dark(#ffffff, #0f1115);
                 --error: light-dark(#a3261d, #ffb4ab);
             }
         }
@@ -60,7 +62,7 @@
             background-color: var(--bg);
             color: var(--fg);
             font-family: system-ui, sans-serif;
-            line-height: 1.5;
+            line-height: 1.6;
             margin: 0 auto;
             max-width: 45rem;
             padding: 1rem;
@@ -92,7 +94,7 @@
             text-wrap: pretty;
         }
         h1 {
-            font-size: 1.6rem;
+            font-size: 1.9rem;
             line-height: 1.2;
             margin: 0 0 1rem;
         }
@@ -121,8 +123,9 @@
             overflow-wrap: anywhere;
         }
         .message {
+            background-color: var(--surface);
             border-color: var(--border);
-            border-radius: 0.25rem;
+            border-radius: 0.75rem;
             border-style: solid;
             border-width: 1px;
             padding: 0.75rem;
@@ -178,6 +181,9 @@
         [aria-invalid="true"] {
             border-color: var(--error);
         }
+        [aria-invalid="true"]:focus-visible {
+            outline-color: var(--error);
+        }
         .actions {
             display: flex;
             gap: 0.5rem;
@@ -203,27 +209,30 @@
             padding: 0;
         }
         nav a {
+            border-radius: 0.5rem;
             display: inline-block;
-            padding: 0.5rem;
+            padding: 0.5rem 0.75rem;
         }
         nav a[aria-current="page"] {
+            background-color: var(--surface);
             font-weight: 700;
-            text-decoration-thickness: 2px;
+            text-decoration-line: none;
         }
         input,
         textarea {
-            background-color: var(--bg);
+            background-color: var(--surface);
             border-color: var(--border);
-            border-radius: 0.25rem;
+            border-radius: 0.5rem;
             border-style: solid;
             border-width: 1px;
             color: inherit;
             font: inherit;
-            padding: 0.35rem 0.5rem;
+            padding: 0.5rem 0.7rem;
         }
         input[type="submit"] {
             background-color: var(--surface);
             cursor: pointer;
+            font-weight: 600;
             min-height: 2.25rem;
             padding-inline: 0.9rem;
         }
@@ -233,7 +242,7 @@
         input[type="submit"].primary {
             background-color: var(--accent);
             border-color: var(--accent);
-            color: var(--bg);
+            color: var(--on-accent);
         }
         input[type="submit"].primary:hover {
             background-color: var(--accent-hover);
@@ -245,14 +254,14 @@
                 --border: var(--fg);
                 --muted: var(--fg);
             }
-            .messages li,
+            .message,
             input,
             textarea {
                 border-width: 2px;
             }
         }
         @media (forced-colors: active) {
-            .messages li,
+            .message,
             input,
             textarea {
                 border-width: 2px;

--- a/src/express/views/common/header.ejs
+++ b/src/express/views/common/header.ejs
@@ -3,8 +3,16 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title><%= title %></title>
+    <%# Paints the right background before the stylesheet is parsed %>
+    <meta name="color-scheme" content="light dark" />
+    <meta name="theme-color" media="(prefers-color-scheme: light)" content="white" />
+    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="black" />
+    <%# No favicon request, no referrer on outbound links %>
+    <link rel="icon" href="data:," />
+    <meta name="referrer" content="no-referrer" />
 
-    <%# light-dark polyfill %>
+    <%# Each color is resolved once, so rules below read a single token. %>
+    <%# light-dark() is the standard; the polyfill beneath it covers older browsers. %>
     <%# https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/light-dark %>
     <style>
         :root {
@@ -19,22 +27,28 @@
             }
         }
         html {
-            --bg_light: white;
-            --bg_dark: black;
-            --font_light: black;
-            --font_dark: white;
-            --surface_light: #ededed;
-            --surface_dark: #1c1c1c;
-            --border_light: #767676;
-            --border_dark: #6e6e6e;
-            --muted_light: #595959;
-            --muted_dark: #a8a8a8;
-            --accent_light: #14477f;
-            --accent_dark: #9dc1f5;
-            --surface_hover_light: #dcdcdc;
-            --surface_hover_dark: #2b2b2b;
-            --accent_hover_light: #0f3560;
-            --accent_hover_dark: #b8d4f8;
+            --bg: var(--light-mode, white) var(--dark-mode, black);
+            --fg: var(--light-mode, black) var(--dark-mode, white);
+            --surface: var(--light-mode, #ededed) var(--dark-mode, #1c1c1c);
+            --surface-hover: var(--light-mode, #dcdcdc) var(--dark-mode, #2b2b2b);
+            --border: var(--light-mode, #767676) var(--dark-mode, #6e6e6e);
+            --muted: var(--light-mode, #595959) var(--dark-mode, #a8a8a8);
+            --accent: var(--light-mode, #14477f) var(--dark-mode, #9dc1f5);
+            --accent-hover: var(--light-mode, #0f3560) var(--dark-mode, #b8d4f8);
+            --error: var(--light-mode, #a3261d) var(--dark-mode, #ffb4ab);
+        }
+        @supports (color: light-dark(black, white)) {
+            html {
+                --bg: light-dark(white, black);
+                --fg: light-dark(black, white);
+                --surface: light-dark(#ededed, #1c1c1c);
+                --surface-hover: light-dark(#dcdcdc, #2b2b2b);
+                --border: light-dark(#767676, #6e6e6e);
+                --muted: light-dark(#595959, #a8a8a8);
+                --accent: light-dark(#14477f, #9dc1f5);
+                --accent-hover: light-dark(#0f3560, #b8d4f8);
+                --error: light-dark(#a3261d, #ffb4ab);
+            }
         }
         *,
         *::before,
@@ -42,8 +56,9 @@
             box-sizing: border-box;
         }
         body {
-            background-color: var(--light-mode, var(--bg_light)) var(--dark-mode, var(--bg_dark));
-            color: var(--light-mode, var(--font_light)) var(--dark-mode, var(--font_dark));
+            accent-color: var(--accent);
+            background-color: var(--bg);
+            color: var(--fg);
             font-family: system-ui, sans-serif;
             line-height: 1.5;
             margin: 0 auto;
@@ -51,13 +66,24 @@
             padding: 1rem;
         }
         a {
-            color: var(--light-mode, var(--accent_light)) var(--dark-mode, var(--accent_dark));
+            color: var(--accent);
         }
         :focus-visible {
-            outline-color: var(--light-mode, var(--accent_light)) var(--dark-mode, var(--accent_dark));
+            outline-color: var(--accent);
             outline-offset: 2px;
             outline-style: solid;
             outline-width: 2px;
+        }
+        .skip {
+            background-color: var(--bg);
+            left: 1rem;
+            padding: 0.5rem;
+            position: absolute;
+            top: 1rem;
+            transform: translateY(-200%);
+        }
+        .skip:focus {
+            transform: none;
         }
         h1 {
             font-size: 1.6rem;
@@ -84,8 +110,12 @@
             margin: 0 0 1.5rem;
             padding: 0;
         }
+        .messages li,
+        .error {
+            overflow-wrap: anywhere;
+        }
         .messages li {
-            border-color: var(--light-mode, var(--border_light)) var(--dark-mode, var(--border_dark));
+            border-color: var(--border);
             border-radius: 0.25rem;
             border-style: solid;
             border-width: 1px;
@@ -97,10 +127,24 @@
             flex-direction: column;
             gap: 0.5rem;
         }
-        .meta {
-            color: var(--light-mode, var(--muted_light)) var(--dark-mode, var(--muted_dark));
-            font-size: 0.85rem;
+        .meta,
+        .empty {
+            color: var(--muted);
             margin: 0;
+        }
+        .meta {
+            font-size: 0.85rem;
+        }
+        .empty {
+            margin-bottom: 1.5rem;
+        }
+        .error {
+            color: var(--error);
+            font-size: 0.9rem;
+            margin: 0;
+        }
+        [aria-invalid="true"] {
+            border-color: var(--error);
         }
         .actions {
             display: flex;
@@ -128,10 +172,14 @@
             display: inline-block;
             padding: 0.5rem;
         }
+        nav a[aria-current="page"] {
+            font-weight: 700;
+            text-decoration-thickness: 2px;
+        }
         input,
         textarea {
-            background-color: var(--light-mode, var(--bg_light)) var(--dark-mode, var(--bg_dark));
-            border-color: var(--light-mode, var(--border_light)) var(--dark-mode, var(--border_dark));
+            background-color: var(--bg);
+            border-color: var(--border);
             border-radius: 0.25rem;
             border-style: solid;
             border-width: 1px;
@@ -140,21 +188,44 @@
             padding: 0.35rem 0.5rem;
         }
         input[type="submit"] {
-            background-color: var(--light-mode, var(--surface_light)) var(--dark-mode, var(--surface_dark));
+            background-color: var(--surface);
             cursor: pointer;
+            min-height: 2.25rem;
             padding-inline: 0.9rem;
         }
         input[type="submit"]:hover {
-            background-color: var(--light-mode, var(--surface_hover_light)) var(--dark-mode, var(--surface_hover_dark));
+            background-color: var(--surface-hover);
         }
         input[type="submit"].primary {
-            background-color: var(--light-mode, var(--accent_light)) var(--dark-mode, var(--accent_dark));
-            border-color: var(--light-mode, var(--accent_light)) var(--dark-mode, var(--accent_dark));
-            color: var(--light-mode, var(--bg_light)) var(--dark-mode, var(--bg_dark));
+            background-color: var(--accent);
+            border-color: var(--accent);
+            color: var(--bg);
         }
         input[type="submit"].primary:hover {
-            background-color: var(--light-mode, var(--accent_hover_light)) var(--dark-mode, var(--accent_hover_dark));
-            border-color: var(--light-mode, var(--accent_hover_light)) var(--dark-mode, var(--accent_hover_dark));
+            background-color: var(--accent-hover);
+            border-color: var(--accent-hover);
+        }
+        <%# Stronger edges when the reader asks for them; system colors take over entirely in forced-colors mode %>
+        @media (prefers-contrast: more) {
+            html {
+                --border: var(--fg);
+                --muted: var(--fg);
+            }
+            .messages li,
+            input,
+            textarea {
+                border-width: 2px;
+            }
+        }
+        @media (forced-colors: active) {
+            .messages li,
+            input,
+            textarea {
+                border-width: 2px;
+            }
+            nav a[aria-current="page"] {
+                text-decoration-line: underline;
+            }
         }
     </style>
 </head>

--- a/src/express/views/common/nav.ejs
+++ b/src/express/views/common/nav.ejs
@@ -1,10 +1,10 @@
-<nav>
+<nav aria-label="Site">
     <ul>
         <li>
-            <a href="/">Home</a>
+            <a href="/"<%- current === '/' ? ' aria-current="page"' : '' %>>Home</a>
         </li>
         <li>
-            <a href="/chat">Chat</a>
+            <a href="/chat"<%- current === '/chat' ? ' aria-current="page"' : '' %>>Chat</a>
         </li>
     </ul>
 </nav>

--- a/src/express/views/common/top.ejs
+++ b/src/express/views/common/top.ejs
@@ -1,0 +1,5 @@
+<a class="skip" href="#main">Skip to content</a>
+<header>
+    <h1><%= heading %></h1>
+    <%- include('nav', { current: current }) %>
+</header>

--- a/src/express/views/pages/chat/index.ejs
+++ b/src/express/views/pages/chat/index.ejs
@@ -12,34 +12,40 @@
             <% } %>
             <ul class="messages">
                 <% for (const msg of msgs) { %>
-                    <%# A rejected edit is shown in the row it came from, with what was submitted %>
+                    <%# A rejected edit reopens the editor in the row it came from, with what was submitted %>
                     <% const own = rejected.id === msg.id && !rejected.errors.id; %>
                     <% const errors = own ? rejected.errors : {}; %>
                     <% const name = own && rejected.name != null ? rejected.name : msg.name; %>
                     <% const content = own && rejected.content != null ? rejected.content : msg.content; %>
                     <li>
-                        <form method="post">
-                            <input type="hidden" name="id" value="<%= msg.id %>" />
-                            <p class="meta">Last modified: <time datetime="<%= msg.dateTime %>"><%= msg.lastModified %></time></p>
-                            <label class="visually-hidden" for="name-<%= msg.id %>">Display name</label>
-                            <% if (errors.name) { %>
-                                <input id="name-<%= msg.id %>" type="text" name="name" autocomplete="off" placeholder="Display name" value="<%= name %>" required maxlength="32" pattern=".*\S.*" title="Display name cannot be blank" aria-invalid="true" aria-describedby="name-<%= msg.id %>-error" autofocus />
-                                <p class="error" id="name-<%= msg.id %>-error"><%= errors.name %></p>
-                            <% } else { %>
-                                <input id="name-<%= msg.id %>" type="text" name="name" autocomplete="off" placeholder="Display name" value="<%= name %>" required maxlength="32" pattern=".*\S.*" title="Display name cannot be blank" />
-                            <% } %>
-                            <label class="visually-hidden" for="content-<%= msg.id %>">Message</label>
-                            <% if (errors.content) { %>
-                                <textarea id="content-<%= msg.id %>" name="content" rows="2" autocomplete="off" placeholder="Say something..." required maxlength="2048" aria-invalid="true" aria-describedby="content-<%= msg.id %>-error"<%= errors.name ? '' : ' autofocus' %>><%= content %></textarea>
-                                <p class="error" id="content-<%= msg.id %>-error"><%= errors.content %></p>
-                            <% } else { %>
-                                <textarea id="content-<%= msg.id %>" name="content" rows="2" autocomplete="off" placeholder="Say something..." required maxlength="2048"><%= content %></textarea>
-                            <% } %>
-                            <div class="actions">
-                                <input type="submit" formaction="/chat/edit?page=<%= page %>" value="Edit" />
-                                <input type="submit" formaction="/chat/delete?page=<%= page %>" value="Delete" formnovalidate />
-                            </div>
-                        </form>
+                        <article class="message" aria-labelledby="author-<%= msg.id %>">
+                            <p class="meta"><b id="author-<%= msg.id %>"><%= msg.name %></b> <time datetime="<%= msg.dateTime %>"><%= msg.lastModified %></time></p>
+                            <p class="content"><%= msg.content %></p>
+                            <details<%= own ? ' open' : '' %>>
+                                <summary>Edit</summary>
+                                <form method="post">
+                                    <input type="hidden" name="id" value="<%= msg.id %>" />
+                                    <label for="name-<%= msg.id %>">Display name</label>
+                                    <% if (errors.name) { %>
+                                        <input id="name-<%= msg.id %>" type="text" name="name" autocomplete="off" placeholder="Display name" value="<%= name %>" required maxlength="32" pattern=".*\S.*" title="Display name cannot be blank" aria-invalid="true" aria-describedby="name-<%= msg.id %>-error" autofocus />
+                                        <p class="error" id="name-<%= msg.id %>-error"><%= errors.name %></p>
+                                    <% } else { %>
+                                        <input id="name-<%= msg.id %>" type="text" name="name" autocomplete="off" placeholder="Display name" value="<%= name %>" required maxlength="32" pattern=".*\S.*" title="Display name cannot be blank" />
+                                    <% } %>
+                                    <label for="content-<%= msg.id %>">Message</label>
+                                    <% if (errors.content) { %>
+                                        <textarea id="content-<%= msg.id %>" name="content" rows="3" autocomplete="off" placeholder="Say something..." required maxlength="2048" aria-invalid="true" aria-describedby="content-<%= msg.id %>-error"<%= errors.name ? '' : ' autofocus' %>><%= content %></textarea>
+                                        <p class="error" id="content-<%= msg.id %>-error"><%= errors.content %></p>
+                                    <% } else { %>
+                                        <textarea id="content-<%= msg.id %>" name="content" rows="3" autocomplete="off" placeholder="Say something..." required maxlength="2048"><%= content %></textarea>
+                                    <% } %>
+                                    <div class="actions">
+                                        <input type="submit" formaction="/chat/edit?page=<%= page %>" value="Save" class="primary" />
+                                        <input type="submit" formaction="/chat/delete?page=<%= page %>" value="Delete" formnovalidate />
+                                    </div>
+                                </form>
+                            </details>
+                        </article>
                     </li>
                 <% } %>
             </ul>

--- a/src/express/views/pages/chat/index.ejs
+++ b/src/express/views/pages/chat/index.ejs
@@ -2,39 +2,73 @@
 <html lang="en">
     <%- include('../../common/header', { title: "Chat" }) %>
     <body>
-        <h1>Chat</h1>
-        <%- include('../../common/nav') %>
-        <main>
+        <%- include('../../common/top', { heading: 'Chat', current: '/chat' }) %>
+        <main id="main">
+            <% if (rejected.errors.id) { %>
+                <p class="error" role="alert"><%= rejected.errors.id %></p>
+            <% } %>
+            <% if (msgs.length === 0) { %>
+                <p class="empty">No messages yet.</p>
+            <% } %>
             <ul class="messages">
-                <% for ( let msg of msgs ) { %>
+                <% for (const msg of msgs) { %>
+                    <%# A rejected edit is shown in the row it came from, with what was submitted %>
+                    <% const own = rejected.id === msg.id && !rejected.errors.id; %>
+                    <% const errors = own ? rejected.errors : {}; %>
+                    <% const name = own && rejected.name != null ? rejected.name : msg.name; %>
+                    <% const content = own && rejected.content != null ? rejected.content : msg.content; %>
                     <li>
                         <form method="post">
                             <input type="hidden" name="id" value="<%= msg.id %>" />
-                            <p class="meta">Last modified: <%= msg.lastModified %></p>
+                            <p class="meta">Last modified: <time datetime="<%= msg.dateTime %>"><%= msg.lastModified %></time></p>
                             <label class="visually-hidden" for="name-<%= msg.id %>">Display name</label>
-                            <input id="name-<%= msg.id %>" type="text" name="name" autocomplete="off" placeholder="Display name" value="<%= msg.name %>" />
+                            <% if (errors.name) { %>
+                                <input id="name-<%= msg.id %>" type="text" name="name" autocomplete="off" placeholder="Display name" value="<%= name %>" required maxlength="32" pattern=".*\S.*" title="Display name cannot be blank" aria-invalid="true" aria-describedby="name-<%= msg.id %>-error" autofocus />
+                                <p class="error" id="name-<%= msg.id %>-error"><%= errors.name %></p>
+                            <% } else { %>
+                                <input id="name-<%= msg.id %>" type="text" name="name" autocomplete="off" placeholder="Display name" value="<%= name %>" required maxlength="32" pattern=".*\S.*" title="Display name cannot be blank" />
+                            <% } %>
                             <label class="visually-hidden" for="content-<%= msg.id %>">Message</label>
-                            <input id="content-<%= msg.id %>" type="text" name="content" autocomplete="off" placeholder="Say something..." value="<%= msg.content %>" />
+                            <% if (errors.content) { %>
+                                <textarea id="content-<%= msg.id %>" name="content" rows="2" autocomplete="off" placeholder="Say something..." required maxlength="2048" aria-invalid="true" aria-describedby="content-<%= msg.id %>-error"<%= errors.name ? '' : ' autofocus' %>><%= content %></textarea>
+                                <p class="error" id="content-<%= msg.id %>-error"><%= errors.content %></p>
+                            <% } else { %>
+                                <textarea id="content-<%= msg.id %>" name="content" rows="2" autocomplete="off" placeholder="Say something..." required maxlength="2048"><%= content %></textarea>
+                            <% } %>
                             <div class="actions">
-                                <input type="submit" formaction="/chat/edit" value="Edit" />
-                                <input type="submit" formaction="/chat/delete" value="Delete" />
+                                <input type="submit" formaction="/chat/edit?page=<%= page %>" value="Edit" />
+                                <input type="submit" formaction="/chat/delete?page=<%= page %>" value="Delete" formnovalidate />
                             </div>
                         </form>
                     </li>
                 <% } %>
             </ul>
             <nav class="pagination" aria-label="Message pages">
-                <a href="?page=<%= page + 1 %>">Older messages</a>
+                <% if (hasOlder) { %>
+                    <a href="?page=<%= page + 1 %>">Older messages</a>
+                <% } %>
                 <% if (page > 1) { %>
                     <a href="?page=<%= page - 1 %>">Newer messages</a>
                 <% } %>
             </nav>
+            <%# A rejected send is shown in the compose form, with what was submitted %>
+            <% const compose = rejected.id == null ? rejected : { errors: {} }; %>
             <form class="compose" action="/chat/send" method="post">
                 <h2>New message</h2>
                 <label for="send-name">Display name</label>
-                <input id="send-name" type="text" name="name" autocomplete="off" placeholder="Display name" />
+                <% if (compose.errors.name) { %>
+                    <input id="send-name" type="text" name="name" autocomplete="off" placeholder="Display name" value="<%= compose.name ?? '' %>" required maxlength="32" pattern=".*\S.*" title="Display name cannot be blank" aria-invalid="true" aria-describedby="send-name-error" autofocus />
+                    <p class="error" id="send-name-error"><%= compose.errors.name %></p>
+                <% } else { %>
+                    <input id="send-name" type="text" name="name" autocomplete="off" placeholder="Display name" value="<%= compose.name ?? '' %>" required maxlength="32" pattern=".*\S.*" title="Display name cannot be blank" />
+                <% } %>
                 <label for="send-content">Message</label>
-                <textarea id="send-content" name="content" rows="4" autocomplete="off" placeholder="Say something..."></textarea>
+                <% if (compose.errors.content) { %>
+                    <textarea id="send-content" name="content" rows="4" autocomplete="off" placeholder="Say something..." required maxlength="2048" aria-invalid="true" aria-describedby="send-content-error"<%= compose.errors.name ? '' : ' autofocus' %>><%= compose.content ?? '' %></textarea>
+                    <p class="error" id="send-content-error"><%= compose.errors.content %></p>
+                <% } else { %>
+                    <textarea id="send-content" name="content" rows="4" autocomplete="off" placeholder="Say something..." required maxlength="2048"><%= compose.content ?? '' %></textarea>
+                <% } %>
                 <input type="submit" value="Send" class="primary" />
             </form>
         </main>

--- a/src/express/views/pages/home/error.ejs
+++ b/src/express/views/pages/home/error.ejs
@@ -2,9 +2,8 @@
 <html lang="en">
     <%- include('../../common/header', { title: 'Error' }) %>
     <body>
-        <h1><%= code %> <%= name %></h1>
-        <%- include('../../common/nav') %>
-        <main>
+        <%- include('../../common/top', { heading: `${code} ${name}`, current: '' }) %>
+        <main id="main">
             <p>If you think this is an error, please contact this site's maintainers.</p>
         </main>
     </body>

--- a/src/express/views/pages/home/index.ejs
+++ b/src/express/views/pages/home/index.ejs
@@ -2,9 +2,8 @@
 <html lang="en">
     <%- include('../../common/header', { title: 'Home' }) %>
     <body>
-        <h1>Home</h1>
-        <%- include('../../common/nav') %>
-        <main>
+        <%- include('../../common/top', { heading: 'Home', current: '/' }) %>
+        <main id="main">
             <p>Welcome. Check out some of our pages.</p>
         </main>
     </body>

--- a/src/express/views/pages/home/status.ejs
+++ b/src/express/views/pages/home/status.ejs
@@ -2,9 +2,8 @@
 <html lang="en">
     <%- include('../../common/header', { title: 'Server Status' }) %>
     <body>
-        <h1>Server Status</h1>
-        <%- include('../../common/nav') %>
-        <main>
+        <%- include('../../common/top', { heading: 'Server Status', current: '' }) %>
+        <main id="main">
             <p><%= msg %></p>
         </main>
     </body>

--- a/src/nginx/html/error.html
+++ b/src/nginx/html/error.html
@@ -5,8 +5,8 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Error</title>
         <meta name="color-scheme" content="light dark" />
-        <meta name="theme-color" media="(prefers-color-scheme: light)" content="white" />
-        <meta name="theme-color" media="(prefers-color-scheme: dark)" content="black" />
+        <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f5f6f8" />
+        <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#0f1115" />
         <link rel="icon" href="data:," />
         <meta name="referrer" content="no-referrer" />
         <style>
@@ -22,26 +22,26 @@
                 }
             }
             html {
-                --bg: var(--light-mode, white) var(--dark-mode, black);
-                --fg: var(--light-mode, black) var(--dark-mode, white);
+                --bg: var(--light-mode, #f5f6f8) var(--dark-mode, #0f1115);
+                --fg: var(--light-mode, #171a1f) var(--dark-mode, #e8eaf0);
             }
             @supports (color: light-dark(black, white)) {
                 html {
-                    --bg: light-dark(white, black);
-                    --fg: light-dark(black, white);
+                    --bg: light-dark(#f5f6f8, #0f1115);
+                    --fg: light-dark(#171a1f, #e8eaf0);
                 }
             }
             body {
                 background-color: var(--bg);
                 color: var(--fg);
                 font-family: system-ui, sans-serif;
-                line-height: 1.5;
+                line-height: 1.6;
                 margin: 0 auto;
                 max-width: 45rem;
                 padding: 1rem;
             }
             h1 {
-                font-size: 1.6rem;
+                font-size: 1.9rem;
                 line-height: 1.2;
                 margin: 0 0 1rem;
             }

--- a/src/nginx/html/error.html
+++ b/src/nginx/html/error.html
@@ -3,6 +3,12 @@
     <head>
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Error</title>
+        <meta name="color-scheme" content="light dark" />
+        <meta name="theme-color" media="(prefers-color-scheme: light)" content="white" />
+        <meta name="theme-color" media="(prefers-color-scheme: dark)" content="black" />
+        <link rel="icon" href="data:," />
+        <meta name="referrer" content="no-referrer" />
         <style>
             :root {
                 color-scheme: light dark;
@@ -16,21 +22,35 @@
                 }
             }
             html {
-                --bg_light: white;
-                --bg_dark: black;
-                --font_light: black;
-                --font_dark: white;
+                --bg: var(--light-mode, white) var(--dark-mode, black);
+                --fg: var(--light-mode, black) var(--dark-mode, white);
+            }
+            @supports (color: light-dark(black, white)) {
+                html {
+                    --bg: light-dark(white, black);
+                    --fg: light-dark(black, white);
+                }
             }
             body {
-                background-color: var(--light-mode, var(--bg_light)) var(--dark-mode, var(--bg_dark));
-                color: var(--light-mode, var(--font_light)) var(--dark-mode, var(--font_dark));
+                background-color: var(--bg);
+                color: var(--fg);
+                font-family: system-ui, sans-serif;
+                line-height: 1.5;
+                margin: 0 auto;
+                max-width: 45rem;
+                padding: 1rem;
+            }
+            h1 {
+                font-size: 1.6rem;
+                line-height: 1.2;
+                margin: 0 0 1rem;
             }
         </style>
-        <title>Error</title>
     </head>
     <body>
-        <h1>Error <!--@ERROR_CODE--></h1>
-        <h2><!--@ERROR_MESSAGE--></h2>
-        <p>If you believe this to be an error, contact the website maintainers.</p>
+        <main>
+            <h1><!--@ERROR_CODE--> <!--@ERROR_MESSAGE--></h1>
+            <p>If you think this is an error, please contact this site's maintainers.</p>
+        </main>
     </body>
 </html>


### PR DESCRIPTION
Closes #170
Closes #109

## Problem

Every message on the board is a form: its author and text sit in an
`input` and a one-line `input`, with Edit and Delete under each. Reading
the board means reading text boxes, and a screen reader announces each
message as an editable field rather than as content. A 2048-character
message is edited in that one line.

The templates carry the a11y basics from #274 but stop short of the
current standard: no skip link, no `header` landmark, no `aria-current`
on the nav, buttons under the WCAG 2.2 target size, and dates as prose.

A rejected form still lands on a bare `400 Bad Request` page (#109).
Nothing stops a blank submission in the browser, and the server accepts
input it should not:

- a name or message of only whitespace, or of a zero-width space, since
  `notEmpty` runs on the raw value
- control characters anywhere, including the bidi overrides that make a
  name render as different text than it is
- an id that no longer exists. The check is an async `custom()` that
  returns `false`, and express-validator treats a resolved promise as a
  pass whatever it resolves to (`context-items/custom-validation.js`),
  so the message written for it never shows
- a message the browser said was fine: `maxlength` counts a newline as
  one character, the form submits it as `\r\n`, and the server counts two

A missing or repeated message or id surfaces express-validator's own
`Invalid value`, since only the name's type check carries a message.
`?page=1e300` produces a `$skip` Mongo cannot take.

A body the parser refuses — malformed JSON, 150 KB, over a thousand fields —
reaches `errorHandler` since #283, but the handler reads only
`res.statusCode`, still 200, so it answers 503 without a database and 500
with one. The parser put 400 or 413 on the error.

The stylesheet spells the light/dark toggle out in every rule, and the
nginx error page shares the mechanism but none of the layout.

## Resolution

**Messages.** Each message is an `article`: author, `<time datetime>`,
and the text as a paragraph that keeps its line breaks. Editing sits
behind a native `details`/`summary` disclosure, closed by default, with
the name, a `textarea`, Save and Delete inside. No script: the browser
owns the open state. A rejected edit reopens that message's editor with
the error beside its field.

**Templates.** A skip link, a `header` landmark and `aria-current="page"`
come from one `common/top.ejs` include. Submit buttons and the `summary`
are 36px tall. The board says so when it is empty, and only offers older
messages when the page is full. Textareas grow with their content where
`field-sizing` is supported.

**Validation in the browser, without scripts.** Every field is `required`
with the server's `maxlength`; the name has a `pattern` that refuses
blanks, with a `title` explaining it. Delete is `formnovalidate`, so an
empty row can still be removed.

**Validation on the server.** The exists check throws. Name and message
are trimmed and must contain a visible character. Names refuse control
and bidi characters; messages allow tab and newline only. `\r\n` is
normalized before the length is measured. Every step has a message of
its own. `page` is clamped so `$skip` fits a 32-bit integer.

`errorHandler` takes the status a parser error carries, so those answer
400 and 413 through the usual error page.

**Errors on the page.** A rejected send re-renders the board with the
message beside its field, `aria-invalid` and `aria-describedby` set,
the text kept and the field focused. A rejected edit does the same in its
own row, on the page it came from. A vanished id shows a `role="alert"`
above the list. Status stays 400.

**Theme.** Each color resolves once to a token through `light-dark()`,
the standard the polyfill emulates, with the polyfill kept as the
`@supports` fallback. Rules read `var(--fg)`. The palette is a tinted
page with white cards, a muted blue accent and a border that clears the
3:1 non-text minimum against both; every pair is at least 4.5:1 for text
in both schemes. Corners are rounded, the current nav item is a card, and
an invalid field's focus ring is the error color rather than the accent. `<meta name="color-scheme">`
paints the right background before the stylesheet parses, `theme-color`
follows the scheme, `accent-color` is set, and `prefers-contrast: more`
and `forced-colors` thicken edges. Long messages wrap. The nginx error
page gets the same head and layout.

`<link rel="icon" href="data:,">` stops the `/favicon.ico` request,
which nginx answers with the error page, and `referrer` is `no-referrer`.

No script, no fetch, nothing retained. There is no theme toggle: without
scripts it needs a cookie, and Tor Browser reports light to every site
regardless.

## Verification

- 29 tests pass, up from 17. New ones cover each rejection above, the
  CRLF count, a repeated field, the 2049th character, page clamping,
  malformed JSON and an oversized body, the inline error markup,
  `aria-current`, the skip link and the absence of `<script>`.
- Every string in the Big List of Naughty Strings, sent as a name and
  as a message: 1030 requests, no 5xx. 753 accepted, then rendered on one
  board, where every tag and attribute is from the template's own set
  and no `<` survives outside a tag. 277 rejected, all for a reason the
  page shows. Not vendored, since it is 30 KB of fixture.
- Every template rendered in every state: unique ids, every `for` and
  `aria-describedby` resolved, at most one `autofocus`. `html-validate`
  recommended + a11y presets pass with the void-element, doctype,
  inline-style and prefer-button rules off, which disagree with this
  repo's style, and one finding for the nginx page's `<h1>` of
  `sub_filter` placeholders.
- Contrast against the page, computed for light and dark: text 16.1:1
  and 15.7:1, accent 6.7:1 and 9.2:1, muted 5.8:1 and 7.4:1, error 6.8:1
  and 11.1:1, borders 3.3:1 and 4.0:1; borders against a card 3.6:1 and
  3.6:1.
- In headless Chromium, 70 checks: axe-core (WCAG 2.x A/AA + best
  practice) clean on every page in light, dark and the error states;
  first Tab is the skip link and Enter lands on `main`; every focused
  element has a ring; the browser blocks an empty or blank form and
  truncates at `maxlength`; Delete still submits from an emptied row;
  a server rejection renders beside its field with the text kept; a
  rejected edit reopens only its own editor; send, edit and delete round
  trips through the disclosure; no horizontal overflow at 375px, in
  forced-colors, or at 200% text with a 2048-character unbroken message;
  `--bg` resolves through `light-dark()`; one request per page load and
  no `/favicon.ico`.
- An adversarial pass over HTTP: tampered ids (empty, SQL, NoSQL
  operator, array, uppercase hex, fullwidth digits), JSON, multipart and
  text bodies, no body, unsupported methods, traversal and null-byte
  paths, an 8 KB path, a 2000-parameter query, every `page` shape,
  right-to-left text, a 16-emoji name, a 1024-emoji message, script and
  attribute-breakout payloads, EJS tags, NBSP- and ZWJ-only messages,
  deleting and editing an already deleted message, 50 parallel sends,
  and reload after a send. Nothing above 499, nothing stored that should
  not be, nothing rendered as markup, and no repeated POST.
- SonarJS recommended rules (`eslint-plugin-sonarjs` 4.2, type-aware)
  over every Express source file: nothing.
- eslint, tsc, markdownlint and the workspace check pass.

## Screenshots

A blank message sent, before and after:

![Before: a bare 400 Bad Request page][rejected-before]
![After: the board, with the message beside its field and the name kept][rejected-after]

The board, before and after (one editor open), and the skip link on a
phone:

![Before][chat-before]
![After][chat-after]
![After, dark][chat-after-dark]
![Skip link][mobile]

[rejected-before]: https://raw.githubusercontent.com/LazyCorpz/onion-site-template/pr-assets/rejected-before.png
[rejected-after]: https://raw.githubusercontent.com/LazyCorpz/onion-site-template/pr-assets/rejected-after.png
[chat-before]: https://raw.githubusercontent.com/LazyCorpz/onion-site-template/pr-assets/chat-before-light.png
[chat-after]: https://raw.githubusercontent.com/LazyCorpz/onion-site-template/pr-assets/chat-after-light.png
[chat-after-dark]: https://raw.githubusercontent.com/LazyCorpz/onion-site-template/pr-assets/chat-after-dark.png
[mobile]: https://raw.githubusercontent.com/LazyCorpz/onion-site-template/pr-assets/after-mobile-skip-link.png

Suggested labels: `enhancement`
