### PR TITLE
feat(mongo): enforce keyfile authorization

### DIFF
--- a/.github/workflows/smoke.sh
+++ b/.github/workflows/smoke.sh
@@ -22,6 +22,10 @@ find src -name '*.example' -not -path 'src/onionprobe/onionprobe/*' \
 
 openssl rand -base64 756 > src/mongo/secrets/keyFile.pem
 chmod 0400 src/mongo/secrets/keyFile.pem
+# mongod reads the keyfile as its own user, so the file takes that owner,
+# as the README asks. A container does the chown so no sudo is needed.
+docker run --rm -v "${PWD}/src/mongo/secrets/keyFile.pem:/keyFile.pem" \
+    mongo:8 chown 999:999 /keyFile.pem
 
 # The root compose file mounts the hostname as a secret, so tor has to
 # generate one first. Tor chowns its bind-mounted directory to a uid this

--- a/README.md
+++ b/README.md
@@ -66,8 +66,10 @@ The same goes with these files, except that these values should be memorable:
 Although this project will work with the example credentials
 in each of these files, **for your own security, please change them.**
 
-Next, create a key file for MongoDB replicas by running
-the following command in the project root:
+Next, create a key file for MongoDB replicas. The replica set members use
+it to authenticate each other, and it turns authorization on, so every
+client needs the credentials above. Run the following command in the
+project root:
 
 ```shell
 openssl rand -base64 756 > ./src/mongo/secrets/keyFile.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,10 +116,14 @@ services:
       service: mongo-init
     container_name: mongo-init
     depends_on:
-      # Replicas will die until this service initializes the replica set
-      - mongo-1
-      - mongo-2
-      - mongo-3
+      # A node's healthcheck initiates the replica set and creates the
+      # administrator, whose credentials this service needs to confirm it
+      mongo-1:
+        condition: service_healthy
+      mongo-2:
+        condition: service_healthy
+      mongo-3:
+        condition: service_healthy
     volumes:
       - type: volume
         source: mongo-db-init
@@ -137,6 +141,8 @@ services:
       file: ./src/docker-compose.yml
       service: mongo
     container_name: mongo-1
+    # Matches its entry in replicas.json
+    hostname: mongo-1
     volumes:
       - type: volume
         source: mongo-db-1
@@ -153,6 +159,8 @@ services:
       file: ./src/docker-compose.yml
       service: mongo
     container_name: mongo-2
+    # Matches its entry in replicas.json
+    hostname: mongo-2
     volumes:
       - type: volume
         source: mongo-db-2
@@ -169,6 +177,8 @@ services:
       file: ./src/docker-compose.yml
       service: mongo
     container_name: mongo-3
+    # Matches its entry in replicas.json
+    hostname: mongo-3
     volumes:
       - type: volume
         source: mongo-db-3
@@ -194,8 +204,14 @@ services:
     environment:
       # Standard configuration details
       - ME_CONFIG_BASICAUTH_ENABLED=true
-      - ME_CONFIG_MONGODB_AUTHDB=admin
-      - ME_CONFIG_MONGODB_URL=mongodb://mongo-1:27017,mongo-2:27017,mongo-3:27017?replicaSet=dataset
+      # mongo-express uses a URL as given, without the credentials below, so
+      # the members are listed and it builds the URL itself. The image's
+      # entrypoint still reads the URL to decide what to wait for, and skips
+      # the wait when the URL lists more than one member
+      - ME_CONFIG_MONGODB_SERVER=mongo-1,mongo-2,mongo-3
+      - ME_CONFIG_MONGODB_PORT=27017
+      - ME_CONFIG_MONGODB_AUTH_DATABASE=admin
+      - ME_CONFIG_MONGODB_URL=mongodb://mongo-1:27017,mongo-2:27017,mongo-3:27017
       # Administrator credentials
       - ME_CONFIG_MONGODB_ADMINUSERNAME_FILE=/run/secrets/root/username.txt
       - ME_CONFIG_MONGODB_ADMINPASSWORD_FILE=/run/secrets/root/password.txt

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -29,19 +29,6 @@ services:
     mem_swappiness: 1
     # https://www.mongodb.com/docs/manual/tutorial/manage-mongodb-processes/#stop-mongod-processes
     stop_signal: SIGTERM
-    configs:
-      - source: mongo-replicas
-        target: /project/replicas.json
-    secrets:
-      - source: mongo-keyfile
-        target: /run/secrets/keyFile.pem
-        mode: 0400
-        uid: '999'
-        gid: '999'
-      - source: mongo-root-username
-        target: /run/secrets/username.txt
-      - source: mongo-root-password
-        target: /run/secrets/password.txt
   mongo:
     restart: unless-stopped
     build:
@@ -52,6 +39,9 @@ services:
     mem_swappiness: 1
     # https://www.mongodb.com/docs/manual/tutorial/manage-mongodb-processes/#stop-mongod-processes
     stop_signal: SIGTERM
+    configs:
+      - source: mongo-replicas
+        target: /docker-entrypoint-initdb.d/replicas.json
     secrets:
       - source: mongo-keyfile
         target: /run/secrets/keyFile.pem

--- a/src/mongo/Dockerfile
+++ b/src/mongo/Dockerfile
@@ -19,11 +19,10 @@ COPY --link --exclude=*.sh --exclude=diagnose.js [ "./", "./" ]
 
 WORKDIR /project/
 COPY --link [ "./diagnose.js", "./" ]
-COPY --link [ "./src/root.js", "./src/" ]
-# Corresponds to user mongodb
-USER 999:999
+COPY --link [ "./src/", "./src/" ]
 COPY --link --chmod=+x [ "./diagnose.sh", "./" ]
 
+# Corresponds to user mongodb
 USER 999:999
 # The keyfile authenticates members to each other and turns authorization on
 CMD [ "mongod", "--replSet", "dataset", "--keyFile", "/run/secrets/keyFile.pem" ]
@@ -43,9 +42,9 @@ FROM ${MONGO_VERSION} AS init
 WORKDIR /project/
 COPY --link [ "./diagnose.js", "./" ]
 COPY --link [ "./src/init.js", "./src/root.js", "./src/" ]
-# 999:999 corresponds to user mongodb
 COPY --link --chmod=+x [ "./index.sh", "./diagnose.sh", "./" ]
 
+# 999:999 corresponds to user mongodb
 USER 999:999
 ENTRYPOINT [ "/project/index.sh" ]
 ENV HOST=mongo

--- a/src/mongo/Dockerfile
+++ b/src/mongo/Dockerfile
@@ -19,26 +19,30 @@ COPY --link --exclude=*.sh --exclude=diagnose.js [ "./", "./" ]
 
 WORKDIR /project/
 COPY --link [ "./diagnose.js", "./" ]
+COPY --link [ "./src/root.js", "./src/" ]
 # Corresponds to user mongodb
 USER 999:999
 COPY --link --chmod=+x [ "./diagnose.sh", "./" ]
 
 USER 999:999
-CMD [ "mongod", "--replSet", "dataset" ]
+# The keyfile authenticates members to each other and turns authorization on
+CMD [ "mongod", "--replSet", "dataset", "--keyFile", "/run/secrets/keyFile.pem" ]
 # mongo recommends a minimum connection interval of 1s to avoid performance degradation
 HEALTHCHECK \
     --interval=2s \
     --timeout=5s \
-    --start-period=1s \
+    # Covers initiation, election and the first user
+    --start-period=30s \
     # Waits for election to complete
     --retries=10 \
     CMD [ "mongosh", "-f", "/docker-entrypoint-initdb.d/src/healthcheck.js" ]
 
-# Initializes replica set
+# Confirms the replica set is up. Initiating it needs localhost, so a node's healthcheck does that
 FROM ${MONGO_VERSION} AS init
 
 WORKDIR /project/
 COPY --link [ "./diagnose.js", "./" ]
+COPY --link [ "./src/init.js", "./src/root.js", "./src/" ]
 # 999:999 corresponds to user mongodb
 COPY --link --chmod=+x [ "./index.sh", "./diagnose.sh", "./" ]
 

--- a/src/mongo/diagnose.js
+++ b/src/mongo/diagnose.js
@@ -167,6 +167,12 @@ try {
      * Runs diagnostics. Logs any issues. Resolution may not always be possible.
      */
     function diagnose() {
+        // serverStatus needs a login now that the keyfile turns authorization on
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        const root = /** @type {typeof import('./src/root')} */ (require(`${__dirname}/src/root`));
+
+        db.getSiblingDB('admin').auth(root.username, root.password);
+
         diagnoseTcmalloc();
         diagnoseEngine();
     }

--- a/src/mongo/global.d.ts
+++ b/src/mongo/global.d.ts
@@ -14,7 +14,7 @@ declare global {
 
 export interface Db {
     adminCommand: (command: 'ping') => { ok: number };
-    auth: (username: string, password: string) => void;
+    auth: (username: string, password: string) => { ok: number };
     createCollection: (name: string) => void;
     createUser: (options: {
         user: string;
@@ -59,6 +59,7 @@ export interface ServerStatusOutputs {
 
 export interface Rs {
     initiate: (config?: RsInitiateConfig) => void;
+    status: () => { ok: number };
 }
 
 export interface RsInitiateConfig {

--- a/src/mongo/index.sh
+++ b/src/mongo/index.sh
@@ -3,4 +3,4 @@
 mongosh \
     --host "${HOST}" \
     --port "${PORT}" \
-    --eval 'try{disableTelemetry();const assert=require("node:assert");try{assert.strictEqual(rs.status().ok,1);}catch{rs.initiate(require("./replicas.json"),{force:true});assert.strictEqual(rs.status().ok,1);}}catch(err){console.error("Failed to initialize replica set:",err);throw err;}'
+    -f '/project/src/init.js'

--- a/src/mongo/src/createUsers.js
+++ b/src/mongo/src/createUsers.js
@@ -3,9 +3,12 @@ const assert = require('node:assert');
 const env = /** @type {typeof import('./env')} */ (require(`${__dirname}/env`));
 
 /**
- * Creates an administrator and a user, if they don't already exist.
+ * Creates the database user, if it doesn't already exist.
  *
- * Throws an error if the users don't exist and the connected node
+ * Expects the connection to be authenticated as the administrator, who is
+ * created by the healthcheck under the localhost exception.
+ *
+ * Throws an error if the user doesn't exist and the connected node
  * isn't a writable primary.
  * @param {import('../global').Db} adminDb
  */
@@ -15,29 +18,6 @@ function createUsers(adminDb) {
     assert.strictEqual(hello.ok, 1,
         `Failed to ping node: ${JSON.stringify(hello)}`);
 
-    const canCreateUser = hello.isWritablePrimary;
-    const adminUsers = adminDb.getUsers();
-
-    assert.strictEqual(adminUsers.ok, 1,
-        `Failed to fetch users from DB admin: ${JSON.stringify(adminUsers)}`);
-
-    if (!adminUsers.users.map((user) => user.user).includes(env.admin.username)) {
-        assert.strictEqual(canCreateUser, true, "Administrator doesn't exist");
-
-        adminDb.createUser({
-            user: env.admin.username,
-            pwd: env.admin.password,
-            roles: [
-                {
-                    role: 'root',
-                    db: 'admin'
-                }
-            ]
-        });
-        console.log('Created administrator!');
-    }
-
-    // Creating user
     // NOTE: Databases and collections are hidden
     // until data is added to them, by default
     const msgBoard = adminDb.getSiblingDB(env.dbName);
@@ -47,12 +27,10 @@ function createUsers(adminDb) {
         `Failed to fetch users from DB ${env.dbName}: ${JSON.stringify(dbUsers)}`);
 
     if (!dbUsers.users.map((user) => user.user).includes(env.user.username)) {
-        assert.strictEqual(canCreateUser, true,
+        assert.strictEqual(hello.isWritablePrimary, true,
             `User of database ${env.dbName} doesn't exist`);
 
         // Creating user with database permissions
-        adminDb.auth(env.admin.username, env.admin.password);
-
         msgBoard.createUser({
             user: env.user.username,
             pwd: env.user.password,

--- a/src/mongo/src/createUsers.js
+++ b/src/mongo/src/createUsers.js
@@ -4,10 +4,7 @@ const env = /** @type {typeof import('./env')} */ (require(`${__dirname}/env`));
 
 /**
  * Creates the database user, if it doesn't already exist.
- *
- * Expects the connection to be authenticated as the administrator, who is
- * created by the healthcheck under the localhost exception.
- *
+ * Expects the connection to be authenticated as the administrator.
  * Throws an error if the user doesn't exist and the connected node
  * isn't a writable primary.
  * @param {import('../global').Db} adminDb

--- a/src/mongo/src/env.js
+++ b/src/mongo/src/env.js
@@ -5,41 +5,12 @@
 const assert = require('node:assert');
 const fs = require('node:fs');
 
-// Environment variables need to be manually included, even when set by Docker
-require('dotenv').config({
-    path: ['/run/secrets/.env'],
-    quiet: true
-});
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const root = /** @type {import('./root')} */ (require(`${__dirname}/root`));
 
 // DB name
 // https://hub.docker.com/_/mongo#initializing-a-fresh-instance
 const dbName = process.env.MONGO_INITDB_DATABASE ?? 'test';
-
-// Admin username
-const adminUsernameFile = process.env.ROOT_USERNAME_FILE;
-assert.ok(
-    adminUsernameFile,
-    'ROOT_USERNAME_FILE is missing from env'
-);
-assert.ok(
-    fs.existsSync(adminUsernameFile),
-    "ROOT_USERNAME_FILE doesn't exist"
-);
-const adminUsername = fs.readFileSync(adminUsernameFile).toString();
-assert.ok(adminUsername, 'Admin username is missing');
-
-// Admin password
-const adminPasswordFile = process.env.ROOT_PASSWORD_FILE;
-assert.ok(
-    adminPasswordFile,
-    'ROOT_PASSWORD_FILE is missing from env'
-);
-assert.ok(
-    fs.existsSync(adminPasswordFile),
-    "ROOT_PASSWORD_FILE doesn't exist"
-);
-const adminPassword = fs.readFileSync(adminPasswordFile).toString();
-assert.ok(adminPassword, 'Admin password is missing');
 
 // Local username
 const localUsernameFile = process.env.USERNAME_FILE;
@@ -58,8 +29,8 @@ assert.ok(localPassword, 'Local password is missing');
 module.exports = {
     dbName: dbName,
     admin: {
-        username: adminUsername,
-        password: adminPassword
+        username: root.username,
+        password: root.password
     },
     user: {
         username: localUsername,

--- a/src/mongo/src/env.js
+++ b/src/mongo/src/env.js
@@ -6,7 +6,7 @@ const assert = require('node:assert');
 const fs = require('node:fs');
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-const root = /** @type {import('./root')} */ (require(`${__dirname}/root`));
+const root = /** @type {typeof import('./root')} */ (require(`${__dirname}/root`));
 
 // DB name
 // https://hub.docker.com/_/mongo#initializing-a-fresh-instance

--- a/src/mongo/src/healthcheck.js
+++ b/src/mongo/src/healthcheck.js
@@ -67,8 +67,10 @@ try {
     if (!authenticate(adminDb, root)) {
         // No user exists yet, so the localhost exception is open
         if (!initiated()) {
-            assert.ok(replicas.isInitiator(config, os.hostname()),
-                `Waiting for ${replicas.initiator(config)} to initiate the replica set (this is ${os.hostname()})`);
+            assert.ok(
+                replicas.isInitiator(config, os.hostname()),
+                `Waiting for ${replicas.initiator(config)} to initiate the replica set (this is ${os.hostname()})`
+            );
 
             rs.initiate(config);
             console.log('Initiated replica set!');

--- a/src/mongo/src/healthcheck.js
+++ b/src/mongo/src/healthcheck.js
@@ -1,6 +1,12 @@
 /*
  * This and all other .js files should be treated as CommonJS:
  * https://www.mongodb.com/docs/mongodb-shell/write-scripts/
+ *
+ * Runs inside each node, over localhost. On a fresh replica set that is the
+ * only place the keyfile lets anything happen: until a user exists, the
+ * localhost exception allows replSetInitiate, replSetGetStatus and createUser,
+ * and nothing else. Once a user exists, only credentials get in.
+ * https://www.mongodb.com/docs/manual/core/localhost-exception/
  */
 
 try {
@@ -8,8 +14,87 @@ try {
     disableTelemetry();
 
     const assert = require('node:assert');
+    const fs = require('node:fs');
+    const os = require('node:os');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const root = /** @type {typeof import('./root')} */ (require(`${__dirname}/root`));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const replicas = /** @type {typeof import('./replicas')} */ (require(`${__dirname}/replicas`));
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const config = /** @type {import('../global').RsInitiateConfig} */ (
+        JSON.parse(fs.readFileSync('/docker-entrypoint-initdb.d/replicas.json').toString())
+    );
 
-    // Creating users, if they don't already exist
+    /**
+     * Authenticates as the administrator
+     * @param {import('../global').Db} adminDb
+     * @param {typeof import('./root')} admin The administrator's credentials
+     * @returns {boolean} `false` if the credentials are refused, which on a fresh node means no user exists yet
+     */
+    function authenticate(adminDb, admin) {
+        try {
+            return adminDb.auth(admin.username, admin.password).ok === 1;
+        }
+        catch (err) {
+            // AuthenticationFailed
+            if (typeof err === 'object' && err != null && 'code' in err && err.code === 18) {
+                return false;
+            }
+
+            throw err;
+        }
+    }
+
+    /**
+     * @returns {boolean} Whether this node belongs to an initiated replica set
+     */
+    function initiated() {
+        try {
+            return rs.status().ok === 1;
+        }
+        catch (err) {
+            // NotYetInitialized
+            if (typeof err === 'object' && err != null && 'code' in err && err.code === 94) {
+                return false;
+            }
+
+            throw err;
+        }
+    }
+
+    const adminDb = db.getSiblingDB('admin');
+
+    if (!authenticate(adminDb, root)) {
+        // No user exists yet, so the localhost exception is open
+        if (!initiated()) {
+            assert.ok(replicas.isInitiator(config, os.hostname()),
+                `Waiting for ${replicas.initiator(config)} to initiate the replica set (this is ${os.hostname()})`);
+
+            rs.initiate(config);
+            console.log('Initiated replica set!');
+        }
+
+        // Users can only be created on the primary, and creating the first one
+        // closes the localhost exception on every node once it replicates
+        assert.strictEqual(db.hello().isWritablePrimary, true,
+            'Waiting for a primary to create the administrator');
+
+        adminDb.createUser({
+            user: root.username,
+            pwd: root.password,
+            roles: [
+                {
+                    role: 'root',
+                    db: 'admin'
+                }
+            ]
+        });
+        console.log('Created administrator!');
+
+        assert.ok(authenticate(adminDb, root), 'Administrator cannot authenticate');
+    }
+
+    // Creating the database user, if it doesn't already exist
     load(`${__dirname}/createUsers.js`);
 
     // Testing DB connection

--- a/src/mongo/src/init.js
+++ b/src/mongo/src/init.js
@@ -17,7 +17,7 @@ try {
         'Administrator cannot authenticate');
     assert.strictEqual(rs.status().ok, 1, 'Replica set is not initiated');
 
-    console.log('Replica set is up');
+    console.log('Replica set is up!');
 }
 catch (err) {
     console.error('Failed to confirm the replica set:', err);

--- a/src/mongo/src/init.js
+++ b/src/mongo/src/init.js
@@ -1,0 +1,25 @@
+/*
+ * Waits for the replica set. Initiating it and creating the first user only
+ * work over localhost with a keyfile, so a node's healthcheck does both; this
+ * confirms the result from the network with the administrator's credentials.
+ */
+
+try {
+    disableTelemetry();
+
+    const assert = require('node:assert');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const root = /** @type {typeof import('./root')} */ (require(`${__dirname}/root`));
+
+    const adminDb = db.getSiblingDB('admin');
+
+    assert.strictEqual(adminDb.auth(root.username, root.password).ok, 1,
+        'Administrator cannot authenticate');
+    assert.strictEqual(rs.status().ok, 1, 'Replica set is not initiated');
+
+    console.log('Replica set is up');
+}
+catch (err) {
+    console.error('Failed to confirm the replica set:', err);
+    throw err;
+}

--- a/src/mongo/src/replicas.js
+++ b/src/mongo/src/replicas.js
@@ -1,0 +1,35 @@
+/**
+ * Which member initiates the replica set
+ */
+
+/**
+ * @typedef {import('../global').RsInitiateConfig} RsInitiateConfig
+ */
+
+/**
+ * Returns the hostname of the member that initiates the replica set: the first one listed
+ * @param {RsInitiateConfig} config The replica set configuration
+ * @returns {string}
+ */
+function initiator(config) {
+    if (config.members.length === 0) {
+        throw new Error('Replica set configuration lists no members');
+    }
+
+    return config.members[0].host.split(':')[0];
+}
+
+/**
+ * Whether this host is the member that initiates the replica set
+ * @param {RsInitiateConfig} config The replica set configuration
+ * @param {string} hostname This host's name
+ * @returns {boolean}
+ */
+function isInitiator(config, hostname) {
+    return initiator(config) === hostname;
+}
+
+module.exports = {
+    initiator: initiator,
+    isInitiator: isInitiator
+};

--- a/src/mongo/src/root.js
+++ b/src/mongo/src/root.js
@@ -1,0 +1,35 @@
+/**
+ * The administrator's credentials, read from the secret files
+ */
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+
+// Environment variables need to be manually included, even when set by Docker.
+// The init image carries no dependencies, so the files fall back to their mount paths.
+try {
+    require('dotenv').config({
+        path: ['/run/secrets/.env'],
+        quiet: true
+    });
+}
+catch {
+    // No dotenv here
+}
+
+const usernameFile = process.env.ROOT_USERNAME_FILE ?? '/run/secrets/root/username.txt';
+const passwordFile = process.env.ROOT_PASSWORD_FILE ?? '/run/secrets/root/password.txt';
+
+assert.ok(fs.existsSync(usernameFile), `Admin username file doesn't exist: ${usernameFile}`);
+assert.ok(fs.existsSync(passwordFile), `Admin password file doesn't exist: ${passwordFile}`);
+
+const username = fs.readFileSync(usernameFile).toString();
+const password = fs.readFileSync(passwordFile).toString();
+
+assert.ok(username, 'Admin username is missing');
+assert.ok(password, 'Admin password is missing');
+
+module.exports = {
+    username: username,
+    password: password
+};

--- a/src/mongo/test/replicas.test.js
+++ b/src/mongo/test/replicas.test.js
@@ -1,0 +1,29 @@
+const assert = require('node:assert/strict');
+const { describe, it } = require('node:test');
+const { initiator, isInitiator } = require('../src/replicas');
+
+/** @type {import('../global').RsInitiateConfig} */
+const config = {
+    _id: 'dataset',
+    members: [
+        { _id: 1, host: 'mongo-1:27017', priority: 2 },
+        { _id: 2, host: 'mongo-2:27017', priority: 1 },
+        { _id: 3, host: 'mongo-3:27017', priority: 1 }
+    ]
+};
+
+void describe('replicas', () => {
+    void it('names the first member, without its port', () => {
+        assert.equal(initiator(config), 'mongo-1');
+    });
+
+    void it('recognizes only that member as the initiator', () => {
+        assert.equal(isInitiator(config, 'mongo-1'), true);
+        assert.equal(isInitiator(config, 'mongo-2'), false);
+        assert.equal(isInitiator(config, 'mongo-1:27017'), false);
+    });
+
+    void it('refuses a configuration with no members', () => {
+        assert.throws(() => initiator({ _id: 'dataset', members: [] }), /no members/);
+    });
+});

--- a/src/mongo/test/root.test.js
+++ b/src/mongo/test/root.test.js
@@ -33,7 +33,7 @@ function load() {
 
 void describe('root', () => {
     beforeEach(() => {
-        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'root-'));
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'root'));
     });
 
     afterEach(() => {
@@ -60,7 +60,7 @@ void describe('root', () => {
     });
 
     void it('refuses a missing file', () => {
-        process.env.ROOT_USERNAME_FILE = path.join(dir, 'nope');
+        process.env.ROOT_USERNAME_FILE = path.join(dir, '-nope');
         process.env.ROOT_PASSWORD_FILE = secret('p', 'hunter2');
 
         assert.throws(load, /doesn't exist/);

--- a/src/mongo/test/root.test.js
+++ b/src/mongo/test/root.test.js
@@ -1,0 +1,68 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { afterEach, beforeEach, describe, it } = require('node:test');
+
+const ROOT_MODULE = require.resolve('../src/root');
+
+/** @type {string} */
+let dir;
+
+/**
+ * @param {string} name
+ * @param {string} contents
+ * @returns {string}
+ */
+function secret(name, contents) {
+    const file = path.join(dir, name);
+
+    fs.writeFileSync(file, contents);
+
+    return file;
+}
+
+function load() {
+    Reflect.deleteProperty(require.cache, ROOT_MODULE);
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const root = /** @type {typeof import('../src/root')} */ (require(ROOT_MODULE));
+
+    return root;
+}
+
+void describe('root', () => {
+    beforeEach(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'root-'));
+    });
+
+    afterEach(() => {
+        delete process.env.ROOT_USERNAME_FILE;
+        delete process.env.ROOT_PASSWORD_FILE;
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    void it('reads the credentials from the files the env names', () => {
+        process.env.ROOT_USERNAME_FILE = secret('u', 'admin');
+        process.env.ROOT_PASSWORD_FILE = secret('p', 'hunter2');
+
+        const root = load();
+
+        assert.equal(root.username, 'admin');
+        assert.equal(root.password, 'hunter2');
+    });
+
+    void it('refuses an empty credential', () => {
+        process.env.ROOT_USERNAME_FILE = secret('u', '');
+        process.env.ROOT_PASSWORD_FILE = secret('p', 'hunter2');
+
+        assert.throws(load, /username is missing/);
+    });
+
+    void it('refuses a missing file', () => {
+        process.env.ROOT_USERNAME_FILE = path.join(dir, 'nope');
+        process.env.ROOT_PASSWORD_FILE = secret('p', 'hunter2');
+
+        assert.throws(load, /doesn't exist/);
+    });
+});


### PR DESCRIPTION
Closes #237

## Problem

`CMD [ "mongod", "--replSet", "dataset" ]` passes no `--keyFile`, so the
keyfile every deployment is told to generate is mounted and never read,
and nothing enforces authentication: anything that reaches 27017 on the
`mongo` network has full access. `createUsers.js` creates both users, but
only the connection string honours them.

Passing `--keyFile` turns authorization on, and that is why #198 backed
it out. Until a user exists, a node accepts only `replSetInitiate`,
`replSetGetStatus`, `replSetReconfig`, `createUser` and `createRole`, and
only over localhost ([localhost exception][exception]). So:

- `mongo-init` cannot initiate the set. It connects over the network.
- The healthcheck's `getUsers()` is refused before the first user exists,
  and its `getUsers()` afterwards is refused without credentials.
- `mongo-express` crashes: `ME_CONFIG_MONGODB_URL` is used as given, and
  the `ADMINUSERNAME_FILE`/`ADMINPASSWORD_FILE` variables only ever feed
  a URL the image builds itself.
- `diagnose.js` calls `serverStatus`, which needs a login.
- `smoke.sh` leaves the keyfile owned by the runner, so `mongod`, as
  `999`, cannot open it. The README already asks deployers to `chown` it.

## Resolution

The healthcheck runs inside each node over localhost, so it is the one
place the exception applies. It tries the administrator's credentials
first. If they are refused, no user exists yet: the member listed first
in `replicas.json` initiates the set, whichever member becomes primary
creates the administrator (which closes the exception everywhere once it
replicates), and it authenticates. The database user is created from
there as before. Secondaries fail the check until the users replicate,
then pass on credentials. Each node gets `hostname:` and the replica
config so it can tell whether it is the initiator.

`mongo-init` keeps its place in the dependency graph, waits for the
nodes to be healthy, and confirms with the administrator's credentials
from the network that the set is up.

`mongo-express` gets `ME_CONFIG_MONGODB_SERVER` with the members listed,
so it builds its own URL with the credentials; the URL stays, in the
multi-member form, only so the image's entrypoint skips its readiness
wait. `diagnose.js` logs in first. `smoke.sh` gives the keyfile to `999`
through a container, so no `sudo` is needed. The healthcheck's
`start-period` grows to cover initiation and election.

Root credentials move to `src/root.js`, read from the mounted files with
a fallback for the init image, which carries no dependencies; the
initiator rule lives in `src/replicas.js`. Both have tests.

## Verification

With Docker, from empty volumes, three times: all three nodes healthy,
`mongo-init` exits 0 without a restart, express, nginx and tor healthy,
in one to three minutes, most of it tor. Only `mongo-1`'s log carries `replSetInitiate admin command
received`. `diagnose.sh` runs on a node. Then, from the network:

- without credentials, reading `msg_board` and `rs.status()` are both
  `Unauthorized`
- the administrator authenticates; members are `PRIMARY`, `SECONDARY`,
  `SECONDARY`; `admin/root` and `user/readWrite` exist
- the database user writes `msg_board` and is `Unauthorized` on `admin`
- a wrong password is `Authentication failed`
- `getCmdLineOpts` reports the keyfile
- after `restart` of all three nodes, healthy again in 10s on credentials,
  and express still answers 200
- `mongo-debug`, under `--profile development`, answers 401 without basic
  auth, 200 with it, and lists `admin`, `config`, `local` and `msg_board`

10 mongo tests pass, up from 4. eslint, tsc, markdownlint and the
workspace check pass.

[exception]: https://www.mongodb.com/docs/manual/core/localhost-exception/

Suggested labels: `enhancement`
